### PR TITLE
Fix version validation rule to use full-matching

### DIFF
--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -46,7 +46,7 @@ class NewCommand extends Command
         }
 
         $symfonyVersion = $input->getArgument('version');
-        if (!preg_match('/\A2\.\d\.\d+\z/', $symfonyVersion)) {
+        if (!preg_match('/^2\.\d\.\d+$/', $symfonyVersion)) {
             throw new \RuntimeException("The Symfony version should be 2.N.M, where N = 0..9 and M = 0..99");
         }
 


### PR DESCRIPTION
Currently:

```
% symfony new blog/ a2.2.5

 Downloading Symfony...

  [GuzzleHttp\Exception\ClientException]                                                                                              
  Client error response [url] http://get.symfony.com/Symfony_Standard_Vendors_a2.2.5.zip [status code] 403 [reason phrase] Forbidden  

new name [version]
```

After fixed:

```
% symfony new blog/ a2.2.5

  [RuntimeException]                                                 
  The Symfony version should be 2.N.M, where N = 0..9 and M = 0..99  

new name [version]
```
