### PR TITLE
Tweaked progress bar animation

### DIFF
--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -105,9 +105,9 @@ MESSAGE;
                 $progressBar->setRedrawFrequency(max(1, floor($size / 1000)));
 
                 if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
-                    $progressBar->setEmptyBarCharacter('░');
-                    $progressBar->setProgressCharacter('▏');
-                    $progressBar->setBarCharacter('▋');
+                    $progressBar->setEmptyBarCharacter('░'); // light shade character \u2591
+                    $progressBar->setProgressCharacter('');
+                    $progressBar->setBarCharacter('▓'); // dark shade character \u2593
                 }
 
                 $progressBar->setBarWidth(60);


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/162986/4667182/5c288312-555a-11e4-848f-ffd6e278a18c.gif)

After:
![after](https://cloud.githubusercontent.com/assets/162986/4667184/600e8986-555a-11e4-89aa-e7ea9a62781e.gif)

I know it's subjective but I think the second one looks better. Tested on Ubuntu 14.04.
