### PR TITLE
Added box config to build phar files

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,28 +1,28 @@
 {
-	"directories": ["src/"],
-	"finder": [
-		{
-			"name": "*.php",
-			"exclude": [
-				".gitignore",
-				".md",
-				"phpunit",
-				"Tester",
-				"Tests",
-				"tests",
-				"yaml"
-			],
-			"in": "vendor"
-		}
-	],
-	"compactors": [
-		"Herrera\\Box\\Compactor\\Json",
-		"Herrera\\Box\\Compactor\\Php"
-	],
-	"compression": "GZ",
-	"git-version": "package_version",
-	"main": "symfony",
-	"output": "symfony.phar",
-	"stub": true,
-	"chmod": "0755"
+    "directories": ["src/"],
+    "finder": [
+        {
+            "name": "*.php",
+            "exclude": [
+                ".gitignore",
+                ".md",
+                "phpunit",
+                "Tester",
+                "Tests",
+                "tests",
+                "yaml"
+            ],
+            "in": "vendor"
+        }
+    ],
+    "compactors": [
+        "Herrera\\Box\\Compactor\\Json",
+        "Herrera\\Box\\Compactor\\Php"
+    ],
+    "compression": "GZ",
+    "git-version": "package_version",
+    "main": "symfony",
+    "output": "symfony.phar",
+    "stub": true,
+    "chmod": "0755"
 }


### PR DESCRIPTION
With the box.json config file, you can easily create the phar file with http://box-project.org/

Once box is installed, just run box build from the directory of the symfony-installer. Make sure you ran composer install before.
