### PR TITLE
Add global shorten command for symfony app/console

### DIFF
--- a/sf
+++ b/sf
@@ -2,9 +2,9 @@
 <?php
 
 	if (file_exists(getcwd() . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'console')) {
-		chdir(getcwd());
-		array_shift($argv);		
-		passthru('app/console ' . implode(' ' , $argv));
+		array_shift($argv);
+		$escapedArgs = array_map(function($arg){ return escapeshellcmd($arg); }, $argv);
+		passthru('php app/console ' . implode(' ' , $escapedArgs));
 	} else {
 		echo "You must be in a symfony project to execute this command.\n";
 	}

--- a/sf
+++ b/sf
@@ -1,10 +1,19 @@
 #!/usr/bin/env php
 <?php
 
-	if (file_exists(getcwd() . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'console')) {
-		array_shift($argv);
-		$escapedArgs = array_map(function($arg){ return escapeshellcmd($arg); }, $argv);
-		passthru('php app/console ' . implode(' ' , $escapedArgs));
-	} else {
-		echo "You must be in a symfony project to execute this command.\n";
-	}
+function execute($consolePath)
+{
+    array_shift($argv);
+    $escapedArgs = array_map(function($arg){ return escapeshellcmd($arg); }, $argv);
+    passthru('php ' . $consolePath . ' ' . implode(' ' , $escapedArgs));
+}
+
+if (file_exists('app/console')) {
+    execute('app/console');
+} elseif (file_exists('bin/console')) {
+    execute('bin/console');
+} else {
+    $STDERR = fopen('php://stderr', 'w+');
+    fwrite($STDERR, "You must be in a symfony project to execute this command.\n");
+    exit(1);
+}

--- a/sf
+++ b/sf
@@ -1,0 +1,10 @@
+#!/usr/bin/env php
+<?php
+
+	if (file_exists(getcwd() . DIRECTORY_SEPARATOR . 'app' . DIRECTORY_SEPARATOR . 'console')) {
+		chdir(getcwd());
+		array_shift($argv);		
+		passthru('app/console ' . implode(' ' , $argv));
+	} else {
+		echo "You must be in a symfony project to execute this command.\n";
+	}


### PR DESCRIPTION
Proposal of a global command shortened for symfony app/console that could be packaged with the symfony installer. It could be then evaluated as a more complete command than just a forwarding command in the future.