### PR TITLE
Trim trailing slash to prevent renaming issues

### DIFF
--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -41,7 +41,7 @@ class NewCommand extends Command
     {
         $this->fs = new Filesystem();
 
-        if (is_dir($dir = getcwd().DIRECTORY_SEPARATOR.$input->getArgument('name'))) {
+        if (is_dir($dir = rtrim(getcwd().DIRECTORY_SEPARATOR.$input->getArgument('name'), DIRECTORY_SEPARATOR))) {
             throw new \RuntimeException(sprintf("Project directory already exists:\n%s", $dir));
         }
 


### PR DESCRIPTION
The README suggests creating a new Symfony project with the command `symfony new blog/`. However the trailing slash makes the process throw an IOException, or at least this is true on OS X Yosemite. This PR will prevent this from happening.

With trailing slash

``` bash
$ symfony new blogforranting/

 Downloading Symfony...
   10.44 MB/10.44 MB [▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋] 100%

 Preparing project...



  [Symfony\Component\Filesystem\Exception\IOException]                                                 
  Cannot rename "/Users/adam/Sites/blogforranting/Symfony/app" to "/Users/adam/Sites/blogforranting//../../Symfony/app/".  



new name [version]
```

Without trailing slash

``` bash
$ symfony new blogforranting

 Downloading Symfony...
   10.44 MB/10.44 MB [▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋▋] 100%

 Preparing project...

 ✔  Symfony was successfully installed. Now you can:

    * Configure your application in app/config/parameters.yml file.

    * Run your application:
        1. Execute the php app/console server:run command.
        2. Browse to the http://localhost:8000 URL.

    * Read the documentation at http://symfony.com/doc
```

Exception trace for first scenario:

```
Exception trace:
 () at /Users/adam/.composer/vendor/symfony/filesystem/Symfony/Component/Filesystem/Filesystem.php:264
 Symfony\Component\Filesystem\Filesystem->rename() at /Users/adam/.composer/vendor/symfony/symfony-installer/src/Symfony/Installer/NewCommand.php:154
 Symfony\Installer\NewCommand->extract() at /Users/adam/.composer/vendor/symfony/symfony-installer/src/Symfony/Installer/NewCommand.php:63
 Symfony\Installer\NewCommand->execute() at /Users/adam/.composer/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:252
 Symfony\Component\Console\Command\Command->run() at /Users/adam/.composer/vendor/symfony/console/Symfony/Component/Console/Application.php:889
 Symfony\Component\Console\Application->doRunCommand() at /Users/adam/.composer/vendor/symfony/console/Symfony/Component/Console/Application.php:193
 Symfony\Component\Console\Application->doRun() at /Users/adam/.composer/vendor/symfony/console/Symfony/Component/Console/Application.php:124
 Symfony\Component\Console\Application->run() at /Users/adam/.composer/vendor/symfony/symfony-installer/symfony:16
```
