### PR TITLE
improve error message for PHP < 5.4

### DIFF
--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -48,9 +48,14 @@ To solve this issue, upgrade your PHP installation or install Symfony manually.
 To do so, make sure that your system has Composer installed and execute the
 following command:
 
-$ composer create-project symfony/framework-standard-edition %s
+$ composer create-project symfony/framework-standard-edition %s %s
 MESSAGE;
-            $output->writeln(sprintf($message, PHP_VERSION, $input->getArgument('name')));
+            $output->writeln(sprintf(
+                $message,
+                PHP_VERSION,
+                $input->getArgument('name'),
+                $input->getArgument('version') !== 'latest' ? $input->getArgument('version') : ''
+            ));
 
             return 1;
         }


### PR DESCRIPTION
When the user uses a PHP version smaller than 5.4, they are not able
to use the Symfony Installer. Instead, they are presented a nice error
message telling them to use the `composer create-project` command
instead. However, if that command is executed without a version
number, the user will get the latest stable release of the Symfony
Standard Edition. Especially when the user passed a custom version
number to the Symfony Installer, this might not be the desired
version. Therefore, it is reasonable to pass the required version
number to Composer.
