### PR TITLE
Improve "About" command contents, which are used as the installer help

### DIFF
--- a/src/Symfony/Installer/AboutCommand.php
+++ b/src/Symfony/Installer/AboutCommand.php
@@ -52,15 +52,15 @@ class AboutCommand extends Command
  To create a new project called <info>blog</info> in the current directory using
  the <info>latest stable version</info> of Symfony, execute the following command:
 
-   <comment>$ symfony new blog</comment>
+   <comment>$ %s new blog</comment>
 
  To base your project on a <info>specific Symfony version</info>, append the version
  number at the end of the command:
 
-   <comment>$ symfony new blog 2.5.6</comment>
+   <comment>$ %s new blog 2.5.6</comment>
 
 COMMAND_HELP;
 
-        $output->writeln(sprintf($commandHelp, $this->appVersion));
+        $output->writeln(sprintf($commandHelp, $this->appVersion, $_SERVER['PHP_SELF'], $_SERVER['PHP_SELF']));
     }
 }


### PR DESCRIPTION
Improved the contents of the "About" command which is used as the installer help

**Before**

![before](https://cloud.githubusercontent.com/assets/73419/5103605/d7989eb2-6fd9-11e4-95fa-5efd7b8a89d7.png)

**After**

![after](https://cloud.githubusercontent.com/assets/73419/5103608/da4d574c-6fd9-11e4-95a2-fa3b878f313a.png)
