### PR TITLE
Improved commands during linux's installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This step is only needed the first time you use the installer:
 ```bash
 curl -LsS http://symfony.com/installer > symfony.phar
 sudo mv symfony.phar /usr/local/bin/symfony
-sudo chmod a+x /usr/local/bin/symfony
+chmod a+x /usr/local/bin/symfony
 ```
 
 ### Windows


### PR DESCRIPTION
I noticed two problems during the installation on linux. I couldn't copy all commands, because of the dollar sign before each line. I prefer to avoid this - it's much more comfortable to copy all three lines at the one time
