### PR TITLE
Always show size with 2 decimal places

### DIFF
--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -314,6 +314,6 @@ class NewCommand extends Command
 
         $bytes /= pow(1024, $pow);
 
-        return round($bytes, 2).' '.$units[$pow];
+        return number_format($bytes, 2).' '.$units[$pow];
     }
 }


### PR DESCRIPTION
Prevents the decimal precision display jumping around when progress is updated
