### PR TITLE
Fixed a visual glitch in the progress bar

### DIFF
--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -197,7 +197,7 @@ class NewCommand extends Command
                     return $this->formatSize($bar->getMaxSteps());
                 });
                 ProgressBar::setPlaceholderFormatterDefinition('current', function (ProgressBar $bar) {
-                    return str_pad($this->formatSize($bar->getStep()), 10, ' ', STR_PAD_LEFT);
+                    return str_pad($this->formatSize($bar->getStep()), 11, ' ', STR_PAD_LEFT);
                 });
 
                 $progressBar = new ProgressBar($this->output, $size);


### PR DESCRIPTION
I don't know if others suffered this problem, but on my computer (Mac OS + iTerm 2) there was a visual glitch in the progress bar that wrongly showed two percent signs when the download size goes from KB to MB:

**Before**

![symfony_installer_before](https://cloud.githubusercontent.com/assets/73419/5180762/dddfc204-748f-11e4-9444-277de8839b03.gif)

**After**

![symfony_installer_after](https://cloud.githubusercontent.com/assets/73419/5180763/e02bc288-748f-11e4-8061-7e03138ab4b2.gif)
