### PR TITLE
Link to the correct version of the docs

### DIFF
--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -323,8 +323,9 @@ class NewCommand extends Command
             "    * Run your application:\n".
             "        1. Execute the <comment>php app/console server:run</comment> command.\n".
             "        2. Browse to the <comment>http://localhost:8000</comment> URL.\n\n".
-            "    * Read the documentation at <comment>http://symfony.com/doc</comment>\n",
-            $this->projectName
+            "    * Read the documentation at <comment>http://symfony.com/doc/%s</comment>\n",
+            $this->projectName,
+            substr($this->version, 0, 3)
         ));
 
         return $this;


### PR DESCRIPTION
Instead of linking to the current docs always, it's better to link to the correct version.
