### PR TITLE
suggest to use symfony.phar on Windows

### DIFF
--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -240,8 +240,9 @@ class NewCommand extends Command
                 throw new \RuntimeException(sprintf(
                     "The selected version (%s) cannot be installed because it does not exist.\n".
                     "Try the special \"latest\" version to install the latest stable Symfony release:\n".
-                    'php symfony %s %s latest',
+                    '%s %s %s latest',
                     $this->version,
+                    defined('PHP_WINDOWS_VERSION_BUILD') ? 'php symfony.phar' : 'symfony',
                     $this->getName(),
                     $this->projectName
                 ));


### PR DESCRIPTION
The command that is suggested since #59 when the download of a non-existent Symfony version fails, is not sufficient on Windows. We need to suggest `php symfony.phar ...` instead.
