### PR TITLE
Generate the `secret` parameter automatically for new Symfony projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "guzzlehttp/progress-subscriber": "~1.1",
         "symfony/console": "~2.5",
         "symfony/filesystem": "~2.5",
-        "symfony/yaml": "~2.5",
         "raulfraile/distill": "~0.7"
     },
     "extra": {

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * This command creates new Symfony projects for the given Symfony version.
@@ -396,12 +395,8 @@ class NewCommand extends Command
             return $this;
         }
 
-        $ret = Yaml::parse($filename);
-
-        $ret['parameters']['secret'] = $this->generateRandomSecret();
-
-        $yaml = Yaml::dump($ret, 2);
-        file_put_contents($filename, $yaml);
+        $ret = str_replace('ThisTokenIsNotSoSecretChangeIt', $this->generateRandomSecret(), file_get_contents($filename));
+        file_put_contents($filename, $ret);
 
         return $this;
     }


### PR DESCRIPTION
As per #77 I've added generating secret key and putting it into `app/config/parameters.yml`.

I've didn't throw any exception in case file would't be writable, as I believe such situation is not possible?

If this should be done in a different way (or with better error handling) please let me know.
