### PR TITLE
Installer now generates a good project name for composer.json

### DIFF
--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -410,7 +410,7 @@ class NewCommand extends Command
             if ($this->output->isVerbose()) {
                 $this->output->writeln(sprintf(
                     " <comment>[WARNING]</comment> The value of the <info>secret</info> configuration option cannot be updated because\n".
-                    " <comment>%s</comment> file is not writable.\n",
+                    " the <comment>%s</comment> file is not writable.\n",
                     $filename
                 ));
             }
@@ -438,7 +438,7 @@ class NewCommand extends Command
             if ($this->output->isVerbose()) {
                 $this->output->writeln(sprintf(
                     " <comment>[WARNING]</comment> Project name cannot be configured because\n".
-                    " <comment>%s</comment> file is not writable.\n",
+                    " the <comment>%s</comment> file is not writable.\n",
                     $filename
                 ));
             }


### PR DESCRIPTION
This fixes #78 and it's completely based on the [code used by Composer](https://github.com/composer/composer/blob/4a3bc58adfd501fa6e82c82fdd9e8d4036898fa1/src/Composer/Command/InitCommand.php#L172-186) and reported by @stof.

In addition to the generation of the project name, this PR reorders and adds missing docs for some methods.
