### PR TITLE
Improved the way we display the executed installer command

### DIFF
--- a/src/Symfony/Installer/AboutCommand.php
+++ b/src/Symfony/Installer/AboutCommand.php
@@ -97,8 +97,7 @@ COMMAND_UPDATE_HELP;
         $executedCommandDir = dirname($executedCommand);
 
         if (in_array($executedCommandDir, $pathDirs)) {
-            $executedCommand = str_replace($executedCommandDir, '', $executedCommand);
-            $executedCommand = trim($executedCommand, DIRECTORY_SEPARATOR);
+            $executedCommand = basename($executedCommand);
         }
 
         return $executedCommand;

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -567,8 +567,7 @@ class NewCommand extends Command
         $executedCommandDir = dirname($executedCommand);
 
         if (in_array($executedCommandDir, $pathDirs)) {
-            $executedCommand = str_replace($executedCommandDir, '', $executedCommand);
-            $executedCommand = trim($executedCommand, DIRECTORY_SEPARATOR);
+            $executedCommand = basename($executedCommand);
         }
 
         return sprintf('%s new %s %s', $executedCommand, $this->projectName, $version);


### PR DESCRIPTION
This PR tries to solve #80 for the most used case.  Around 80% of users use Linux or Mac and most of them will install the installer in `/usr/local/bin/`, so we can easily improve commands' output.
