### PR TITLE
Fix bug #symfony/12019

### DIFF
--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -489,7 +489,7 @@ class NewCommand extends Command
     /**
      * Utility method to show the number of bytes in a readable format.
      *
-     * @param int     $bytes The number of bytes to format
+     * @param int $bytes The number of bytes to format
      *
      * @return string The human readable string of bytes (e.g. 4.32MB)
      */
@@ -537,6 +537,12 @@ class NewCommand extends Command
             $cmdInfo = fread($cmdHandler, 2096);
             pclose($cmdHandler);
             $cmdInfo = explode("\n", $cmdInfo);
+            for ($i = 0; $i < count($cmdInfo); $i++) {
+                if (trim(substr($cmdInfo[$i], -4, 3)) == "CON") {
+                    $cols = intval(trim(substr($cmdInfo[$i+3], -4, 4)));
+                    break;
+                }
+            }
             $cols = intval(trim(substr($cmdInfo[9], -4, 4)));
         } else {
             $cols = exec('tput cols');

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -533,7 +533,7 @@ class NewCommand extends Command
     {
         $cols;
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $cmdHandler = popen('more', 'r');
+            $cmdHandler = popen('mode', 'r');
             $cmdInfo = fread($cmdHandler, 2096);
             pclose($cmdHandler);
             $cmdInfo = explode("\n", $cmdInfo);

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -537,13 +537,13 @@ class NewCommand extends Command
             $cmdInfo = fread($cmdHandler, 2096);
             pclose($cmdHandler);
             $cmdInfo = explode("\n", $cmdInfo);
+            $cols = 80;
             for ($i = 0; $i < count($cmdInfo); $i++) {
                 if (trim(substr($cmdInfo[$i], -4, 3)) == "CON") {
                     $cols = intval(trim(substr($cmdInfo[$i+3], -4, 4)));
                     break;
                 }
             }
-            $cols = intval(trim(substr($cmdInfo[9], -4, 4)));
         } else {
             $cols = exec('tput cols');
         }

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -236,9 +236,9 @@ class NewCommand extends Command
                 });
 
                 $progressBar = new ProgressBar($this->output, $size);
-                $progressBar->setFormat('%current%/%max% %bar%  %percent:3s%%');
+                $progressBar->setFormat($this->suggestProgressBarFormat());
                 $progressBar->setRedrawFrequency(max(1, floor($size / 1000)));
-                $progressBar->setBarWidth(60);
+                $progressBar->setBarWidth($this->suggestProgressBarWidth());
 
                 if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
                     $progressBar->setEmptyBarCharacter('░'); // light shade character \u2591
@@ -504,6 +504,49 @@ class NewCommand extends Command
         $bytes /= pow(1024, $pow);
 
         return number_format($bytes, 2).' '.$units[$pow];
+    }
+
+    /**
+     * Generates the suggested width of the progress bar, based on terminal
+     * width.
+     * 
+     * @return int
+     */
+    private function suggestProgressBarWidth()
+    {
+        $cols = (!defined('PHP_WINDOWS_VERSION_BUILD')) ? exec('tput cols') : 0;
+
+        if($cols >= 87) {
+            return 60;
+        } else {
+            return $cols - 27;
+        }
+    }
+
+    /**
+     * Generates a responsive format for the progress bar, based on terminal
+     * width.
+     * 
+     * @return string
+     */
+    private function suggestProgressBarFormat()
+    {
+        $cols;
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $cmdHandler = popen('more', 'r');
+            $cmdInfo = fread($cmdHandler, 2096);
+            pclose($cmdHandler);
+            $cmdInfo = explode("\n", $cmdInfo);
+            $cols = intval(trim(substr($cmdInfo[9], -4, 4)));
+        } else {
+            $cols = exec('tput cols');
+        }
+
+        if ($cols >= 30) {
+            return '%current%/%max% %bar%  %percent:3s%%';
+        } else {
+            return '%current%/%max% %percent:3s%%';
+        }
     }
 
     /**

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -509,14 +509,14 @@ class NewCommand extends Command
     /**
      * Generates the suggested width of the progress bar, based on terminal
      * width.
-     * 
+     *
      * @return int
      */
     private function suggestProgressBarWidth()
     {
         $cols = (!defined('PHP_WINDOWS_VERSION_BUILD')) ? exec('tput cols') : 0;
 
-        if($cols >= 87) {
+        if ($cols >= 87) {
             return 60;
         } else {
             return $cols - 27;
@@ -526,7 +526,7 @@ class NewCommand extends Command
     /**
      * Generates a responsive format for the progress bar, based on terminal
      * width.
-     * 
+     *
      * @return string
      */
     private function suggestProgressBarFormat()


### PR DESCRIPTION
To fix this bug I have made an algorithm that sets the progress bar's width according to the columns of a terminal window.

The code uses external programs, "tput" for Linux/Unix systems and "mode" for Windows, to get the total columns of the window. In case of a terminal too wide, the code sets the width of the progress bar to the original value (60 chars). In case of a terminal too narrow, the code ignores the progress bar and displays only the file size and the percentage of the download. 

The bug was posted here: https://github.com/symfony/symfony/issues/13019