### PR TITLE
Added a new "symfony demo" command

### DIFF
--- a/src/Symfony/Installer/AboutCommand.php
+++ b/src/Symfony/Installer/AboutCommand.php
@@ -54,20 +54,21 @@ class AboutCommand extends Command
 
    <comment>%s new blog</comment>
 
- To create a new project called <info>blog</info> in the current directory using
- the <info>long term support version</info> of Symfony, execute the following command:
+ Create a project based on the <info>Symfony Long Term Support version</info> (LTS):
 
    <comment>%3\$s new blog lts</comment>
 
- To base your project on a <info>specific Symfony branch</info>, append the branch
- number at the end of the command:
+ Create a project based on a <info>specific Symfony branch</info>:
 
    <comment>%3\$s new blog 2.3</comment>
 
- To base your project on a <info>specific Symfony version</info>, append the version
- number at the end of the command:
+ Create a project based on a <info>specific Symfony version</info>:
 
    <comment>%3\$s new blog 2.5.6</comment>
+
+ Create a <info>Symfony demo application</info> to learn how it works:
+
+   <comment>%3\$s demo</comment>
 
 COMMAND_HELP;
 

--- a/src/Symfony/Installer/DemoCommand.php
+++ b/src/Symfony/Installer/DemoCommand.php
@@ -11,42 +11,26 @@
 
 namespace Symfony\Installer;
 
-use Distill\Distill;
-use Distill\Exception\IO\Input\FileCorruptedException;
-use Distill\Exception\IO\Input\FileEmptyException;
-use Distill\Exception\IO\Output\TargetDirectoryNotWritableException;
-use Distill\Strategy\MinimumSize;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Subscriber\Progress\Progress;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * This command creates new Symfony projects for the given Symfony version.
+ * This command creates a full-featured Symfony demo application.
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-class DemoCommand extends Command
+class DemoCommand extends DownloadCommand
 {
-    /**
-     * @var Filesystem
-     */
-    private $fs;
-    private $projectName;
-    private $projectDir;
-    private $version;
-    private $compressedFilePath;
-    private $requirementsErrors = array();
-
-    /**
-     * @var OutputInterface
-     */
-    private $output;
+    /** @var Filesystem */
+    protected $fs;
+    protected $projectName;
+    protected $projectDir;
+    protected $remoteFileUrl;
+    protected $downloadedFilePath;
+    protected $requirementsErrors = array();
+    /** @var OutputInterface */
+    protected $output;
 
     protected function configure()
     {
@@ -58,8 +42,9 @@ class DemoCommand extends Command
 
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
-        $this->fs = new Filesystem();
+        $this->remoteFileUrl = 'http://symfony.com/download?v=Symfony_Demo';
         $this->output = $output;
+        $this->fs = new Filesystem();
         $this->projectDir = getcwd();
 
         $i = 1;
@@ -79,7 +64,6 @@ class DemoCommand extends Command
                 ->download()
                 ->extract()
                 ->cleanUp()
-                ->updateParameters()
                 ->createGitIgnore()
                 ->checkSymfonyRequirements()
                 ->displayInstallationResult()
@@ -91,139 +75,6 @@ class DemoCommand extends Command
     }
 
     /**
-     * Chooses the best compressed file format to download (ZIP or TGZ) depending upon the
-     * available operating system uncompressing commands and the enabled PHP extensions
-     * and it downloads the file.
-     *
-     * @return demoCommand
-     *
-     * @throws \RuntimeException if the Symfony archive could not be downloaded
-     */
-    private function download()
-    {
-        $this->output->writeln("\n Downloading Demo Application...");
-
-        // decide which is the best compressed version to download
-        $distill = new Distill();
-        $demoArchiveFile = $distill
-            ->getChooser()
-            ->setStrategy(new MinimumSize())
-            ->addFilesWithDifferentExtensions('http://symfony.com/download?v=Symfony_Demo', ['zip', 'tgz'])
-            ->getPreferredFile()
-        ;
-
-        /** @var ProgressBar|null $progressBar */
-        $progressBar = null;
-        $downloadCallback = function ($size, $downloaded, $client, $request, Response $response) use (&$progressBar) {
-            // Don't initialize the progress bar for redirects as the size is much smaller
-            if ($response->getStatusCode() >= 300) {
-                return;
-            }
-
-            if (null === $progressBar) {
-                ProgressBar::setPlaceholderFormatterDefinition('max', function (ProgressBar $bar) {
-                    return $this->formatSize($bar->getMaxSteps());
-                });
-                ProgressBar::setPlaceholderFormatterDefinition('current', function (ProgressBar $bar) {
-                    return str_pad($this->formatSize($bar->getStep()), 11, ' ', STR_PAD_LEFT);
-                });
-
-                $progressBar = new ProgressBar($this->output, $size);
-                $progressBar->setFormat('%current%/%max% %bar%  %percent:3s%%');
-                $progressBar->setRedrawFrequency(max(1, floor($size / 1000)));
-                $progressBar->setBarWidth(60);
-
-                if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
-                    $progressBar->setEmptyBarCharacter('░'); // light shade character \u2591
-                    $progressBar->setProgressCharacter('');
-                    $progressBar->setBarCharacter('▓'); // dark shade character \u2593
-                }
-
-                $progressBar->start();
-            }
-
-            $progressBar->setProgress($downloaded);
-        };
-
-        $client = new Client();
-        $client->getEmitter()->attach(new Progress(null, $downloadCallback));
-
-        // store the file in a temporary hidden directory with a random name
-        $this->compressedFilePath = getcwd().DIRECTORY_SEPARATOR.'.'.uniqid(time()).DIRECTORY_SEPARATOR.'symfony_demo.'.pathinfo($demoArchiveFile, PATHINFO_EXTENSION);
-
-        try {
-            $response = $client->get($demoArchiveFile);
-        } catch (ClientException $e) {
-            throw new \RuntimeException(sprintf("The Symfony Demo application couldn't be downloaded because of the following error:\n%s", $e->getMessage()));
-        }
-
-        $this->fs->dumpFile($this->compressedFilePath, $response->getBody());
-
-        if (null !== $progressBar) {
-            $progressBar->finish();
-            $this->output->writeln("\n");
-        }
-
-        return $this;
-    }
-
-    /**
-     * Extracts the compressed file (ZIP or TGZ) using the
-     * native operating system commands if available or PHP code otherwise.
-     *
-     * @return DemoCommand
-     *
-     * @throws \RuntimeException if the downloaded archive could not be extracted
-     */
-    private function extract()
-    {
-        $this->output->writeln(" Preparing project...\n");
-
-        try {
-            $distill = new Distill();
-            $extractionSucceeded = $distill->extractWithoutRootDirectory($this->compressedFilePath, $this->projectDir);
-        } catch (FileCorruptedException $e) {
-            throw new \RuntimeException(sprintf(
-                "Symfony Demo Application can't be installed because the downloaded package is corrupted.\n".
-                "To solve this issue, try running this command again.\n%s",
-                $this->getExecutedCommand()
-            ));
-        } catch (FileEmptyException $e) {
-            throw new \RuntimeException(sprintf(
-                "Symfony Demo Application can't be installed because the downloaded package is empty.\n".
-                "To solve this issue, try running this command again.\n%s",
-                $this->getExecutedCommand()
-            ));
-        } catch (TargetDirectoryNotWritableException $e) {
-            throw new \RuntimeException(sprintf(
-                "Symfony Demo Application can't be installed because the installer doesn't have enough\n".
-                "permissions to uncompress and rename the package contents.\n".
-                "To solve this issue, check the permissions of the %s directory and\n".
-                "try running this command again.\n%s",
-                getcwd(), $this->getExecutedCommand()
-            ));
-        } catch (\Exception $e) {
-            throw new \RuntimeException(sprintf(
-                "Symfony Demo Application can't be installed because the downloaded package is corrupted\n".
-                "or because the installer doesn't have enough permissions to uncompress and\n".
-                "rename the package contents.\n".
-                "To solve this issue, check the permissions of the %s directory and\n".
-                "try running this command again.\n%s",
-                getcwd(), $this->getExecutedCommand()
-            ));
-        }
-
-        if (!$extractionSucceeded) {
-            throw new \RuntimeException(
-                "Symfony Demo Application can't be installed because the downloaded package is corrupted\n".
-                "or because the uncompress commands of your operating system didn't work."
-            );
-        }
-
-        return $this;
-    }
-
-    /**
      * Removes all the temporary files and directories created to
      * download the demo application.
      *
@@ -231,7 +82,7 @@ class DemoCommand extends Command
      */
     private function cleanUp()
     {
-        $this->fs->remove(dirname($this->compressedFilePath));
+        $this->fs->remove(dirname($this->downloadedFilePath));
 
         return $this;
     }
@@ -276,161 +127,5 @@ class DemoCommand extends Command
         ));
 
         return $this;
-    }
-
-    /**
-     * Checks if environment meets Symfony requirements
-     *
-     * @return DemoCommand
-     */
-    private function checkSymfonyRequirements()
-    {
-        require $this->projectDir.'/app/SymfonyRequirements.php';
-        $symfonyRequirements = new \SymfonyRequirements();
-        $this->requirementsErrors = array();
-        foreach ($symfonyRequirements->getRequirements() as $req) {
-            if ($helpText = $this->getErrorMessage($req)) {
-                $this->requirementsErrors[] = $helpText;
-            }
-        }
-
-        return $this;
-    }
-
-    /**
-     * Updates the Symfony parameters.yml file to replace default configuration
-     * values with better generated values.
-     *
-     * @return NewCommand
-     */
-    private function updateParameters()
-    {
-        $filename = $this->projectDir.'/app/config/parameters.yml';
-
-        if (!is_writable($filename)) {
-            if ($this->output->isVerbose()) {
-                $this->output->writeln(sprintf(
-                    " <comment>[WARNING]</comment> The value of the <info>secret</info> configuration option cannot be updated because\n".
-                    " the <comment>%s</comment> file is not writable.\n",
-                    $filename
-                ));
-            }
-
-            return $this;
-        }
-
-        $ret = str_replace('ThisTokenIsNotSoSecretChangeIt', $this->generateRandomSecret(), file_get_contents($filename));
-        file_put_contents($filename, $ret);
-
-        return $this;
-    }
-
-    /**
-     * Creates the appropriate .gitignore file for a Symfony project.
-     *
-     * @return NewCommand
-     */
-    private function createGitIgnore()
-    {
-        $gitIgnoreEntries = array(
-            '/app/bootstrap.php.cache',
-            '/app/cache/*',
-            '!app/cache/.gitkeep',
-            '/app/config/parameters.yml',
-            '/app/logs/*',
-            '!app/logs/.gitkeep',
-            '/app/phpunit.xml',
-            '/bin/',
-            '/composer.phar',
-            '/vendor/',
-            '/web/bundles/',
-        );
-
-        try {
-            $this->fs->dumpFile($this->projectDir.'/.gitignore', implode("\n", $gitIgnoreEntries)."\n");
-        } catch (\Exception $e) {
-            // don't throw an exception in case the .gitignore file cannot be created,
-            // because this is just an enhancement, not something mandatory for the project
-        }
-
-        return $this;
-    }
-
-    /**
-     * Utility method to show the number of bytes in a readable format.
-     *
-     * @param int $bytes The number of bytes to format
-     *
-     * @return string The human readable string of bytes (e.g. 4.32MB)
-     */
-    private function formatSize($bytes)
-    {
-        $units = array('B', 'KB', 'MB', 'GB', 'TB');
-
-        $bytes = max($bytes, 0);
-        $pow = $bytes ? floor(log($bytes, 1024)) : 0;
-        $pow = min($pow, count($units) - 1);
-
-        $bytes /= pow(1024, $pow);
-
-        return number_format($bytes, 2).' '.$units[$pow];
-    }
-
-    /**
-     * Formats the error message contained in the given Requirement item
-     * using the optional line length provided.
-     *
-     * @param \Requirement $requirement The Symfony requirements
-     * @param int          $lineSize    The maximum line length
-     *
-     * @return string
-     */
-    private function getErrorMessage(\Requirement $requirement, $lineSize = 70)
-    {
-        if ($requirement->isFulfilled()) {
-            return;
-        }
-
-        $errorMessage  = wordwrap($requirement->getTestMessage(), $lineSize - 3, PHP_EOL.'   ').PHP_EOL;
-        $errorMessage .= '   > '.wordwrap($requirement->getHelpText(), $lineSize - 5, PHP_EOL.'   > ').PHP_EOL;
-
-        return $errorMessage;
-    }
-
-    /**
-     * Generates a good random value for Symfony's 'secret' option
-     *
-     * @return string
-     */
-    private function generateRandomSecret()
-    {
-        if (function_exists('openssl_random_pseudo_bytes')) {
-            return hash('sha1', openssl_random_pseudo_bytes(23));
-        }
-
-        return hash('sha1', uniqid(mt_rand(), true));
-    }
-
-    /**
-     * Returns the executed command.
-     *
-     * @return string
-     */
-    private function getExecutedCommand()
-    {
-        $version = '';
-        if ('latest' !== $this->version) {
-            $version = $this->version;
-        }
-
-        $pathDirs = explode(PATH_SEPARATOR, $_SERVER['PATH']);
-        $executedCommand = $_SERVER['PHP_SELF'];
-        $executedCommandDir = dirname($executedCommand);
-
-        if (in_array($executedCommandDir, $pathDirs)) {
-            $executedCommand = basename($executedCommand);
-        }
-
-        return sprintf('%s new %s %s', $executedCommand, $this->projectName, $version);
     }
 }

--- a/src/Symfony/Installer/DemoCommand.php
+++ b/src/Symfony/Installer/DemoCommand.php
@@ -1,0 +1,436 @@
+<?php
+
+/*
+ * This file is part of the Symfony Installer package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Installer;
+
+use Distill\Distill;
+use Distill\Exception\IO\Input\FileCorruptedException;
+use Distill\Exception\IO\Input\FileEmptyException;
+use Distill\Exception\IO\Output\TargetDirectoryNotWritableException;
+use Distill\Strategy\MinimumSize;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Message\Response;
+use GuzzleHttp\Subscriber\Progress\Progress;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * This command creates new Symfony projects for the given Symfony version.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+class DemoCommand extends Command
+{
+    /**
+     * @var Filesystem
+     */
+    private $fs;
+    private $projectName;
+    private $projectDir;
+    private $version;
+    private $compressedFilePath;
+    private $requirementsErrors = array();
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    protected function configure()
+    {
+        $this
+            ->setName('demo')
+            ->setDescription('Creates a demo Symfony project.')
+        ;
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->fs = new Filesystem();
+        $this->output = $output;
+        $this->projectDir = getcwd();
+
+        $i = 1;
+        $projectName = 'symfony_demo';
+        while (file_exists($this->projectDir.DIRECTORY_SEPARATOR.$projectName)) {
+            $projectName = 'symfony_demo_'.(++$i);
+        }
+
+        $this->projectName = $projectName;
+        $this->projectDir = $this->projectDir.DIRECTORY_SEPARATOR.$projectName;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $this
+                ->download()
+                ->extract()
+                ->cleanUp()
+                ->updateParameters()
+                ->createGitIgnore()
+                ->checkSymfonyRequirements()
+                ->displayInstallationResult()
+            ;
+        } catch (\Exception $e) {
+            $this->cleanUp();
+            throw $e;
+        }
+    }
+
+    /**
+     * Chooses the best compressed file format to download (ZIP or TGZ) depending upon the
+     * available operating system uncompressing commands and the enabled PHP extensions
+     * and it downloads the file.
+     *
+     * @return demoCommand
+     *
+     * @throws \RuntimeException if the Symfony archive could not be downloaded
+     */
+    private function download()
+    {
+        $this->output->writeln("\n Downloading Demo Application...");
+
+        // decide which is the best compressed version to download
+        $distill = new Distill();
+        $demoArchiveFile = $distill
+            ->getChooser()
+            ->setStrategy(new MinimumSize())
+            ->addFilesWithDifferentExtensions('http://symfony.com/download?v=Symfony_Demo', ['zip', 'tgz'])
+            ->getPreferredFile()
+        ;
+
+        /** @var ProgressBar|null $progressBar */
+        $progressBar = null;
+        $downloadCallback = function ($size, $downloaded, $client, $request, Response $response) use (&$progressBar) {
+            // Don't initialize the progress bar for redirects as the size is much smaller
+            if ($response->getStatusCode() >= 300) {
+                return;
+            }
+
+            if (null === $progressBar) {
+                ProgressBar::setPlaceholderFormatterDefinition('max', function (ProgressBar $bar) {
+                    return $this->formatSize($bar->getMaxSteps());
+                });
+                ProgressBar::setPlaceholderFormatterDefinition('current', function (ProgressBar $bar) {
+                    return str_pad($this->formatSize($bar->getStep()), 11, ' ', STR_PAD_LEFT);
+                });
+
+                $progressBar = new ProgressBar($this->output, $size);
+                $progressBar->setFormat('%current%/%max% %bar%  %percent:3s%%');
+                $progressBar->setRedrawFrequency(max(1, floor($size / 1000)));
+                $progressBar->setBarWidth(60);
+
+                if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
+                    $progressBar->setEmptyBarCharacter('░'); // light shade character \u2591
+                    $progressBar->setProgressCharacter('');
+                    $progressBar->setBarCharacter('▓'); // dark shade character \u2593
+                }
+
+                $progressBar->start();
+            }
+
+            $progressBar->setProgress($downloaded);
+        };
+
+        $client = new Client();
+        $client->getEmitter()->attach(new Progress(null, $downloadCallback));
+
+        // store the file in a temporary hidden directory with a random name
+        $this->compressedFilePath = getcwd().DIRECTORY_SEPARATOR.'.'.uniqid(time()).DIRECTORY_SEPARATOR.'symfony_demo.'.pathinfo($demoArchiveFile, PATHINFO_EXTENSION);
+
+        try {
+            $response = $client->get($demoArchiveFile);
+        } catch (ClientException $e) {
+            throw new \RuntimeException(sprintf("The Symfony Demo application couldn't be downloaded because of the following error:\n%s", $e->getMessage()));
+        }
+
+        $this->fs->dumpFile($this->compressedFilePath, $response->getBody());
+
+        if (null !== $progressBar) {
+            $progressBar->finish();
+            $this->output->writeln("\n");
+        }
+
+        return $this;
+    }
+
+    /**
+     * Extracts the compressed file (ZIP or TGZ) using the
+     * native operating system commands if available or PHP code otherwise.
+     *
+     * @return DemoCommand
+     *
+     * @throws \RuntimeException if the downloaded archive could not be extracted
+     */
+    private function extract()
+    {
+        $this->output->writeln(" Preparing project...\n");
+
+        try {
+            $distill = new Distill();
+            $extractionSucceeded = $distill->extractWithoutRootDirectory($this->compressedFilePath, $this->projectDir);
+        } catch (FileCorruptedException $e) {
+            throw new \RuntimeException(sprintf(
+                "Symfony Demo Application can't be installed because the downloaded package is corrupted.\n".
+                "To solve this issue, try running this command again.\n%s",
+                $this->getExecutedCommand()
+            ));
+        } catch (FileEmptyException $e) {
+            throw new \RuntimeException(sprintf(
+                "Symfony Demo Application can't be installed because the downloaded package is empty.\n".
+                "To solve this issue, try running this command again.\n%s",
+                $this->getExecutedCommand()
+            ));
+        } catch (TargetDirectoryNotWritableException $e) {
+            throw new \RuntimeException(sprintf(
+                "Symfony Demo Application can't be installed because the installer doesn't have enough\n".
+                "permissions to uncompress and rename the package contents.\n".
+                "To solve this issue, check the permissions of the %s directory and\n".
+                "try running this command again.\n%s",
+                getcwd(), $this->getExecutedCommand()
+            ));
+        } catch (\Exception $e) {
+            throw new \RuntimeException(sprintf(
+                "Symfony Demo Application can't be installed because the downloaded package is corrupted\n".
+                "or because the installer doesn't have enough permissions to uncompress and\n".
+                "rename the package contents.\n".
+                "To solve this issue, check the permissions of the %s directory and\n".
+                "try running this command again.\n%s",
+                getcwd(), $this->getExecutedCommand()
+            ));
+        }
+
+        if (!$extractionSucceeded) {
+            throw new \RuntimeException(
+                "Symfony Demo Application can't be installed because the downloaded package is corrupted\n".
+                "or because the uncompress commands of your operating system didn't work."
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Removes all the temporary files and directories created to
+     * download the demo application.
+     *
+     * @return NewCommand
+     */
+    private function cleanUp()
+    {
+        $this->fs->remove(dirname($this->compressedFilePath));
+
+        return $this;
+    }
+
+    /**
+     * It displays the message with the result of installing the Symfony Demo
+     * application and provides some pointers to the user.
+     *
+     * @return DemoCommand
+     */
+    private function displayInstallationResult()
+    {
+        if (empty($this->requirementsErrors)) {
+            $this->output->writeln(sprintf(
+                " <info>%s</info>  Symfony Demo Application was <info>successfully installed</info>. Now you can:\n",
+                defined('PHP_WINDOWS_VERSION_BUILD') ? 'OK' : '✔'
+            ));
+        } else {
+            $this->output->writeln(sprintf(
+                " <comment>%s</comment>  Symfony Demo Application was <info>successfully installed</info> but your system doesn't meet the\n".
+                "     technical requirements to run Symfony applications! Fix the following issues before executing it:\n",
+                defined('PHP_WINDOWS_VERSION_BUILD') ? 'FAILED' : '✕'
+            ));
+
+            foreach ($this->requirementsErrors as $helpText) {
+                $this->output->writeln(' * '.$helpText);
+            }
+
+            $this->output->writeln(sprintf(
+                " After fixing these issues, re-check Symfony requirements executing this command:\n\n".
+                "   <comment>php %s/app/check.php</comment>\n\n".
+                " Then, you can:\n",
+                $this->projectName
+            ));
+        }
+
+        $this->output->writeln(sprintf(
+            "    1. Change your current directory to <comment>%s</comment>\n\n".
+            "    2. Execute the <comment>php app/console server:run</comment> command to run the demo application.\n\n".
+            "    3. Browse to the <comment>http://localhost:8000</comment> URL to see the demo application in action.\n\n",
+            $this->projectDir
+        ));
+
+        return $this;
+    }
+
+    /**
+     * Checks if environment meets Symfony requirements
+     *
+     * @return DemoCommand
+     */
+    private function checkSymfonyRequirements()
+    {
+        require $this->projectDir.'/app/SymfonyRequirements.php';
+        $symfonyRequirements = new \SymfonyRequirements();
+        $this->requirementsErrors = array();
+        foreach ($symfonyRequirements->getRequirements() as $req) {
+            if ($helpText = $this->getErrorMessage($req)) {
+                $this->requirementsErrors[] = $helpText;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Updates the Symfony parameters.yml file to replace default configuration
+     * values with better generated values.
+     *
+     * @return NewCommand
+     */
+    private function updateParameters()
+    {
+        $filename = $this->projectDir.'/app/config/parameters.yml';
+
+        if (!is_writable($filename)) {
+            if ($this->output->isVerbose()) {
+                $this->output->writeln(sprintf(
+                    " <comment>[WARNING]</comment> The value of the <info>secret</info> configuration option cannot be updated because\n".
+                    " the <comment>%s</comment> file is not writable.\n",
+                    $filename
+                ));
+            }
+
+            return $this;
+        }
+
+        $ret = str_replace('ThisTokenIsNotSoSecretChangeIt', $this->generateRandomSecret(), file_get_contents($filename));
+        file_put_contents($filename, $ret);
+
+        return $this;
+    }
+
+    /**
+     * Creates the appropriate .gitignore file for a Symfony project.
+     *
+     * @return NewCommand
+     */
+    private function createGitIgnore()
+    {
+        $gitIgnoreEntries = array(
+            '/app/bootstrap.php.cache',
+            '/app/cache/*',
+            '!app/cache/.gitkeep',
+            '/app/config/parameters.yml',
+            '/app/logs/*',
+            '!app/logs/.gitkeep',
+            '/app/phpunit.xml',
+            '/bin/',
+            '/composer.phar',
+            '/vendor/',
+            '/web/bundles/',
+        );
+
+        try {
+            $this->fs->dumpFile($this->projectDir.'/.gitignore', implode("\n", $gitIgnoreEntries)."\n");
+        } catch (\Exception $e) {
+            // don't throw an exception in case the .gitignore file cannot be created,
+            // because this is just an enhancement, not something mandatory for the project
+        }
+
+        return $this;
+    }
+
+    /**
+     * Utility method to show the number of bytes in a readable format.
+     *
+     * @param int $bytes The number of bytes to format
+     *
+     * @return string The human readable string of bytes (e.g. 4.32MB)
+     */
+    private function formatSize($bytes)
+    {
+        $units = array('B', 'KB', 'MB', 'GB', 'TB');
+
+        $bytes = max($bytes, 0);
+        $pow = $bytes ? floor(log($bytes, 1024)) : 0;
+        $pow = min($pow, count($units) - 1);
+
+        $bytes /= pow(1024, $pow);
+
+        return number_format($bytes, 2).' '.$units[$pow];
+    }
+
+    /**
+     * Formats the error message contained in the given Requirement item
+     * using the optional line length provided.
+     *
+     * @param \Requirement $requirement The Symfony requirements
+     * @param int          $lineSize    The maximum line length
+     *
+     * @return string
+     */
+    private function getErrorMessage(\Requirement $requirement, $lineSize = 70)
+    {
+        if ($requirement->isFulfilled()) {
+            return;
+        }
+
+        $errorMessage  = wordwrap($requirement->getTestMessage(), $lineSize - 3, PHP_EOL.'   ').PHP_EOL;
+        $errorMessage .= '   > '.wordwrap($requirement->getHelpText(), $lineSize - 5, PHP_EOL.'   > ').PHP_EOL;
+
+        return $errorMessage;
+    }
+
+    /**
+     * Generates a good random value for Symfony's 'secret' option
+     *
+     * @return string
+     */
+    private function generateRandomSecret()
+    {
+        if (function_exists('openssl_random_pseudo_bytes')) {
+            return hash('sha1', openssl_random_pseudo_bytes(23));
+        }
+
+        return hash('sha1', uniqid(mt_rand(), true));
+    }
+
+    /**
+     * Returns the executed command.
+     *
+     * @return string
+     */
+    private function getExecutedCommand()
+    {
+        $version = '';
+        if ('latest' !== $this->version) {
+            $version = $this->version;
+        }
+
+        $pathDirs = explode(PATH_SEPARATOR, $_SERVER['PATH']);
+        $executedCommand = $_SERVER['PHP_SELF'];
+        $executedCommandDir = dirname($executedCommand);
+
+        if (in_array($executedCommandDir, $pathDirs)) {
+            $executedCommand = basename($executedCommand);
+        }
+
+        return sprintf('%s new %s %s', $executedCommand, $this->projectName, $version);
+    }
+}

--- a/src/Symfony/Installer/DownloadCommand.php
+++ b/src/Symfony/Installer/DownloadCommand.php
@@ -1,0 +1,345 @@
+<?php
+
+/*
+ * This file is part of the Symfony Installer package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Installer;
+
+use Distill\Distill;
+use Distill\Exception\IO\Input\FileCorruptedException;
+use Distill\Exception\IO\Input\FileEmptyException;
+use Distill\Exception\IO\Output\TargetDirectoryNotWritableException;
+use Distill\Strategy\MinimumSize;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Message\Response;
+use GuzzleHttp\Subscriber\Progress\Progress;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+
+/**
+ * Abstract command used by commands which download and extract compressed Symfony files.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+abstract class DownloadCommand extends Command
+{
+    /**
+     * Chooses the best compressed file format to download (ZIP or TGZ) depending upon the
+     * available operating system uncompressing commands and the enabled PHP extensions
+     * and it downloads the file.
+     *
+     * @return Command
+     *
+     * @throws \RuntimeException if the Symfony archive could not be downloaded
+     */
+    protected function download()
+    {
+        $this->output->writeln(sprintf("\n Downloading %s...\n", $this->getDownloadedFileName()));
+
+        // decide which is the best compressed version to download
+        $distill = new Distill();
+        $symfonyArchiveFile = $distill
+            ->getChooser()
+            ->setStrategy(new MinimumSize())
+            ->addFilesWithDifferentExtensions($this->remoteFileUrl, ['tgz', 'zip'])
+            ->getPreferredFile()
+        ;
+
+        /** @var ProgressBar|null $progressBar */
+        $progressBar = null;
+        $downloadCallback = function ($size, $downloaded, $client, $request, Response $response) use (&$progressBar) {
+            // Don't initialize the progress bar for redirects as the size is much smaller
+            if ($response->getStatusCode() >= 300) {
+                return;
+            }
+
+            if (null === $progressBar) {
+                ProgressBar::setPlaceholderFormatterDefinition('max', function (ProgressBar $bar) {
+                    return $this->formatSize($bar->getMaxSteps());
+                });
+                ProgressBar::setPlaceholderFormatterDefinition('current', function (ProgressBar $bar) {
+                    return str_pad($this->formatSize($bar->getStep()), 11, ' ', STR_PAD_LEFT);
+                });
+
+                $progressBar = new ProgressBar($this->output, $size);
+                $progressBar->setFormat('%current%/%max% %bar%  %percent:3s%%');
+                $progressBar->setRedrawFrequency(max(1, floor($size / 1000)));
+                $progressBar->setBarWidth(60);
+
+                if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
+                    $progressBar->setEmptyBarCharacter('░'); // light shade character \u2591
+                    $progressBar->setProgressCharacter('');
+                    $progressBar->setBarCharacter('▓'); // dark shade character \u2593
+                }
+
+                $progressBar->start();
+            }
+
+            $progressBar->setProgress($downloaded);
+        };
+
+        $client = new Client();
+        $client->getEmitter()->attach(new Progress(null, $downloadCallback));
+
+        // store the file in a temporary hidden directory with a random name
+        $this->downloadedFilePath = getcwd().DIRECTORY_SEPARATOR.'.'.uniqid(time()).DIRECTORY_SEPARATOR.'symfony.'.pathinfo($symfonyArchiveFile, PATHINFO_EXTENSION);
+
+        try {
+            $response = $client->get($symfonyArchiveFile);
+        } catch (ClientException $e) {
+            if ('new' === $this->getName() && ($e->getCode() === 403 || $e->getCode() === 404)) {
+                throw new \RuntimeException(sprintf(
+                    "The selected version (%s) cannot be installed because it does not exist.\n".
+                    "Execute the following command to install the latest stable Symfony release:\n".
+                    '%s new %s',
+                    $this->version,
+                    $_SERVER['PHP_SELF'],
+                    str_replace(getcwd().DIRECTORY_SEPARATOR, '', $this->projectDir)
+                ));
+            } else {
+                throw new \RuntimeException(sprintf(
+                    "There was an error downloading %s from symfony.com server:\n%s",
+                    $this->getDownloadedFileName(),
+                    $e->getMessage()
+                ));
+            }
+        }
+
+        $this->fs->dumpFile($this->downloadedFilePath, $response->getBody());
+
+        if (null !== $progressBar) {
+            $progressBar->finish();
+            $this->output->writeln("\n");
+        }
+
+        return $this;
+    }
+
+    /**
+     * Extracts the compressed Symfony file (ZIP or TGZ) using the
+     * native operating system commands if available or PHP code otherwise.
+     *
+     * @return NewCommand
+     *
+     * @throws \RuntimeException if the downloaded archive could not be extracted
+     */
+    protected function extract()
+    {
+        $this->output->writeln(" Preparing project...\n");
+
+        try {
+            $distill = new Distill();
+            $extractionSucceeded = $distill->extractWithoutRootDirectory($this->downloadedFilePath, $this->projectDir);
+        } catch (FileCorruptedException $e) {
+            throw new \RuntimeException(sprintf(
+                "%s can't be installed because the downloaded package is corrupted.\n".
+                "To solve this issue, try executing this command again:\n%s",
+                $this->getDownloadedFileName(), $this->getExecutedCommand()
+            ));
+        } catch (FileEmptyException $e) {
+            throw new \RuntimeException(sprintf(
+                "%s can't be installed because the downloaded package is empty.\n".
+                "To solve this issue, try executing this command again:\n%s",
+                $this->getDownloadedFileName(), $this->getExecutedCommand()
+            ));
+        } catch (TargetDirectoryNotWritableException $e) {
+            throw new \RuntimeException(sprintf(
+                "%s can't be installed because the installer doesn't have enough\n".
+                "permissions to uncompress and rename the package contents.\n".
+                "To solve this issue, check the permissions of the %s directory and\n".
+                "try executing this command again:\n%s",
+                $this->getDownloadedFileName(), getcwd(), $this->getExecutedCommand()
+            ));
+        } catch (\Exception $e) {
+            throw new \RuntimeException(sprintf(
+                "%s can't be installed because the downloaded package is corrupted\n".
+                "or because the installer doesn't have enough permissions to uncompress and\n".
+                "rename the package contents.\n".
+                "To solve this issue, check the permissions of the %s directory and\n".
+                "try executing this command again:\n%s",
+                $this->getDownloadedFileName(), getcwd(), $this->getExecutedCommand()
+            ));
+        }
+
+        if (!$extractionSucceeded) {
+            throw new \RuntimeException(sprintf(
+                "%s can't be installed because the downloaded package is corrupted\n".
+                "or because the uncompress commands of your operating system didn't work.",
+                $this->getDownloadedFileName()
+            ));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Checks if environment meets symfony requirements
+     *
+     * @return Command
+     */
+    protected function checkSymfonyRequirements()
+    {
+        require $this->projectDir.'/app/SymfonyRequirements.php';
+        $symfonyRequirements = new \SymfonyRequirements();
+        $this->requirementsErrors = array();
+        foreach ($symfonyRequirements->getRequirements() as $req) {
+            if ($helpText = $this->getErrorMessage($req)) {
+                $this->requirementsErrors[] = $helpText;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Creates the appropriate .gitignore file for a Symfony project.
+     *
+     * @return Command
+     */
+    protected function createGitIgnore()
+    {
+        $gitIgnoreEntries = array(
+            '/app/bootstrap.php.cache',
+            '/app/cache/*',
+            '!app/cache/.gitkeep',
+            '/app/config/parameters.yml',
+            '/app/logs/*',
+            '!app/logs/.gitkeep',
+            '/app/phpunit.xml',
+            '/bin/',
+            '/composer.phar',
+            '/vendor/',
+            '/web/bundles/',
+        );
+
+        try {
+            $this->fs->dumpFile($this->projectDir.'/.gitignore', implode("\n", $gitIgnoreEntries)."\n");
+        } catch (\Exception $e) {
+            // don't throw an exception in case the .gitignore file cannot be created,
+            // because this is just an enhancement, not something mandatory for the project
+        }
+
+        return $this;
+    }
+
+    /**
+     * Utility method to show the number of bytes in a readable format.
+     *
+     * @param int $bytes The number of bytes to format
+     *
+     * @return string The human readable string of bytes (e.g. 4.32MB)
+     */
+    protected function formatSize($bytes)
+    {
+        $units = array('B', 'KB', 'MB', 'GB', 'TB');
+
+        $bytes = max($bytes, 0);
+        $pow = $bytes ? floor(log($bytes, 1024)) : 0;
+        $pow = min($pow, count($units) - 1);
+
+        $bytes /= pow(1024, $pow);
+
+        return number_format($bytes, 2).' '.$units[$pow];
+    }
+
+    /**
+     * Formats the error message contained in the given Requirement item
+     * using the optional line length provided.
+     *
+     * @param \Requirement $requirement The Symfony requirements
+     * @param int          $lineSize    The maximum line length
+     *
+     * @return string
+     */
+    protected function getErrorMessage(\Requirement $requirement, $lineSize = 70)
+    {
+        if ($requirement->isFulfilled()) {
+            return;
+        }
+
+        $errorMessage  = wordwrap($requirement->getTestMessage(), $lineSize - 3, PHP_EOL.'   ').PHP_EOL;
+        $errorMessage .= '   > '.wordwrap($requirement->getHelpText(), $lineSize - 5, PHP_EOL.'   > ').PHP_EOL;
+
+        return $errorMessage;
+    }
+
+    /**
+     * Generates a good random value for Symfony's 'secret' option
+     *
+     * @return string
+     */
+    protected function generateRandomSecret()
+    {
+        if (function_exists('openssl_random_pseudo_bytes')) {
+            return hash('sha1', openssl_random_pseudo_bytes(23));
+        }
+
+        return hash('sha1', uniqid(mt_rand(), true));
+    }
+
+    /**
+     * Returns the executed command with all its arguments
+     * (e.g. "symfony new blog 2.3.6").
+     *
+     * @return string
+     */
+    protected function getExecutedCommand()
+    {
+        $commandBinary = $_SERVER['PHP_SELF'];
+        $commandBinaryDir = dirname($commandBinary);
+        $pathDirs = explode(PATH_SEPARATOR, $_SERVER['PATH']);
+        if (in_array($commandBinaryDir, $pathDirs)) {
+            $commandBinary = basename($commandBinary);
+        }
+
+        $commandName = $this->getName();
+
+        if ('new' === $commandName) {
+            $commandArguments = sprintf('%s %s', $this->projectName, ('latest' !== $this->version) ? $this->version : '');
+        } elseif ('demo' === $commandName) {
+            $commandArguments = '';
+        }
+
+        return sprintf('%s %s %s', $commandBinary, $commandName, $commandArguments);
+    }
+
+    /**
+     * Checks whether the given directory is empty or not.
+     *
+     * @param  string $dir the path of the directory to check
+     * @return bool
+     */
+    protected function isEmptyDirectory($dir)
+    {
+        // glob() cannot be used because it doesn't take into account hidden files
+        // scandir() returns '.'  and '..'  for an empty dir
+        return 2 === count(scandir($dir.'/'));
+    }
+
+    /**
+     * Returns the name of the downloaded file in a human readable format.
+     * @return string
+     */
+    protected function getDownloadedFileName()
+    {
+        $commandName = $this->getName();
+
+        if ('new' === $commandName) {
+            return 'Symfony';
+        }
+
+        if ('demo' === $commandName) {
+            return 'Symfony Demo Application';
+        }
+
+        return '';
+    }
+}

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -11,17 +11,6 @@
 
 namespace Symfony\Installer;
 
-use Distill\Distill;
-use Distill\Exception\IO\Input\FileCorruptedException;
-use Distill\Exception\IO\Input\FileEmptyException;
-use Distill\Exception\IO\Output\TargetDirectoryNotWritableException;
-use Distill\Strategy\MinimumSize;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Subscriber\Progress\Progress;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -33,22 +22,17 @@ use Symfony\Component\Filesystem\Filesystem;
  * @author Christophe Coevoet <stof@notk.org>
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-class NewCommand extends Command
+class NewCommand extends DownloadCommand
 {
-    /**
-     * @var Filesystem
-     */
-    private $fs;
-    private $projectName;
-    private $projectDir;
-    private $version;
-    private $compressedFilePath;
-    private $requirementsErrors = array();
-
-    /**
-     * @var OutputInterface
-     */
-    private $output;
+    /** @var Filesystem */
+    protected $fs;
+    protected $projectName;
+    protected $projectDir;
+    protected $version;
+    protected $downloadedFilePath;
+    protected $requirementsErrors = array();
+    /** @var OutputInterface */
+    protected $output;
 
     protected function configure()
     {
@@ -62,12 +46,14 @@ class NewCommand extends Command
 
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
+        $this->output = $output;
         $this->fs = new Filesystem();
+
         $directory = rtrim(trim($input->getArgument('directory')), DIRECTORY_SEPARATOR);
         $this->projectDir = $this->fs->isAbsolutePath($directory) ? $directory : getcwd().DIRECTORY_SEPARATOR.$directory;
         $this->projectName = basename($directory);
         $this->version = trim($input->getArgument('version'));
-        $this->output = $output;
+        $this->remoteFileUrl = 'http://symfony.com/download?v=Symfony_Standard_Vendors_'.$this->version;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -99,7 +85,7 @@ class NewCommand extends Command
      *
      * @throws \RuntimeException if a project with the same does already exist
      */
-    private function checkProjectName()
+    protected function checkProjectName()
     {
         if (is_dir($this->projectDir) && !$this->isEmptyDirectory($this->projectDir)) {
             throw new \RuntimeException(sprintf(
@@ -129,7 +115,7 @@ class NewCommand extends Command
      *
      * @throws \RuntimeException If the given Symfony version is not compatible with this installer.
      */
-    private function checkSymfonyVersionIsInstallable()
+    protected function checkSymfonyVersionIsInstallable()
     {
         // 'latest' is a special version name that refers to the latest stable version
         // available at the moment of installing Symfony
@@ -206,165 +192,15 @@ class NewCommand extends Command
     }
 
     /**
-     * Chooses the best compressed file format to download (ZIP or TGZ) depending upon the
-     * available operating system uncompressing commands and the enabled PHP extensions
-     * and it downloads the file.
-     *
-     * @return NewCommand
-     *
-     * @throws \RuntimeException if the Symfony archive could not be downloaded
-     */
-    private function download()
-    {
-        $this->output->writeln("\n Downloading Symfony...");
-
-        // decide which is the best compressed version to download
-        $distill = new Distill();
-        $baseName = 'http://symfony.com/download?v=Symfony_Standard_Vendors_'.$this->version;
-        $symfonyArchiveFile = $distill
-            ->getChooser()
-            ->setStrategy(new MinimumSize())
-            ->addFilesWithDifferentExtensions($baseName, ['zip', 'tgz'])
-            ->getPreferredFile()
-        ;
-
-        /** @var ProgressBar|null $progressBar */
-        $progressBar = null;
-        $downloadCallback = function ($size, $downloaded, $client, $request, Response $response) use (&$progressBar) {
-            // Don't initialize the progress bar for redirects as the size is much smaller
-            if ($response->getStatusCode() >= 300) {
-                return;
-            }
-
-            if (null === $progressBar) {
-                ProgressBar::setPlaceholderFormatterDefinition('max', function (ProgressBar $bar) {
-                    return $this->formatSize($bar->getMaxSteps());
-                });
-                ProgressBar::setPlaceholderFormatterDefinition('current', function (ProgressBar $bar) {
-                    return str_pad($this->formatSize($bar->getStep()), 11, ' ', STR_PAD_LEFT);
-                });
-
-                $progressBar = new ProgressBar($this->output, $size);
-                $progressBar->setFormat('%current%/%max% %bar%  %percent:3s%%');
-                $progressBar->setRedrawFrequency(max(1, floor($size / 1000)));
-                $progressBar->setBarWidth(60);
-
-                if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
-                    $progressBar->setEmptyBarCharacter('░'); // light shade character \u2591
-                    $progressBar->setProgressCharacter('');
-                    $progressBar->setBarCharacter('▓'); // dark shade character \u2593
-                }
-
-                $progressBar->start();
-            }
-
-            $progressBar->setProgress($downloaded);
-        };
-
-        $client = new Client();
-        $client->getEmitter()->attach(new Progress(null, $downloadCallback));
-
-        // store the file in a temporary hidden directory with a random name
-        $this->compressedFilePath = getcwd().DIRECTORY_SEPARATOR.'.'.uniqid(time()).DIRECTORY_SEPARATOR.'symfony.'.pathinfo($symfonyArchiveFile, PATHINFO_EXTENSION);
-
-        try {
-            $response = $client->get($symfonyArchiveFile);
-        } catch (ClientException $e) {
-            if ($e->getCode() === 403 || $e->getCode() === 404) {
-                throw new \RuntimeException(sprintf(
-                    "The selected version (%s) cannot be installed because it does not exist.\n".
-                    "Try the special \"latest\" version to install the latest stable Symfony release:\n".
-                    '%s %s %s latest',
-                    $this->version,
-                    $_SERVER['PHP_SELF'],
-                    $this->getName(),
-                    $this->projectDir
-                ));
-            } else {
-                throw new \RuntimeException(sprintf(
-                    "The selected version (%s) couldn't be downloaded because of the following error:\n%s",
-                    $this->version,
-                    $e->getMessage()
-                ));
-            }
-        }
-
-        $this->fs->dumpFile($this->compressedFilePath, $response->getBody());
-
-        if (null !== $progressBar) {
-            $progressBar->finish();
-            $this->output->writeln("\n");
-        }
-
-        return $this;
-    }
-
-    /**
-     * Extracts the compressed Symfony file (ZIP or TGZ) using the
-     * native operating system commands if available or PHP code otherwise.
-     *
-     * @return NewCommand
-     *
-     * @throws \RuntimeException if the downloaded archive could not be extracted
-     */
-    private function extract()
-    {
-        $this->output->writeln(" Preparing project...\n");
-
-        try {
-            $distill = new Distill();
-            $extractionSucceeded = $distill->extractWithoutRootDirectory($this->compressedFilePath, $this->projectDir);
-        } catch (FileCorruptedException $e) {
-            throw new \RuntimeException(sprintf(
-                "Symfony can't be installed because the downloaded package is corrupted.\n".
-                "To solve this issue, try installing Symfony again.\n%s",
-                $this->getExecutedCommand()
-            ));
-        } catch (FileEmptyException $e) {
-            throw new \RuntimeException(sprintf(
-                "Symfony can't be installed because the downloaded package is empty.\n".
-                "To solve this issue, try installing Symfony again.\n%s",
-                $this->getExecutedCommand()
-            ));
-        } catch (TargetDirectoryNotWritableException $e) {
-            throw new \RuntimeException(sprintf(
-                "Symfony can't be installed because the installer doesn't have enough\n".
-                "permissions to uncompress and rename the package contents.\n".
-                "To solve this issue, check the permissions of the %s directory and\n".
-                "try installing Symfony again.\n%s",
-                getcwd(), $this->getExecutedCommand()
-            ));
-        } catch (\Exception $e) {
-            throw new \RuntimeException(sprintf(
-                "Symfony can't be installed because the downloaded package is corrupted\n".
-                "or because the installer doesn't have enough permissions to uncompress and\n".
-                "rename the package contents.\n".
-                "To solve this issue, check the permissions of the %s directory and\n".
-                "try installing Symfony again.\n%s",
-                getcwd(), $this->getExecutedCommand()
-            ));
-        }
-
-        if (!$extractionSucceeded) {
-            throw new \RuntimeException(
-                "Symfony can't be installed because the downloaded package is corrupted\n".
-                "or because the uncompress commands of your operating system didn't work."
-            );
-        }
-
-        return $this;
-    }
-
-    /**
      * Removes all the temporary files and directories created to
      * download the project and removes Symfony-related files that don't make
      * sense in a proprietary project.
      *
      * @return NewCommand
      */
-    private function cleanUp()
+    protected function cleanUp()
     {
-        $this->fs->remove(dirname($this->compressedFilePath));
+        $this->fs->remove(dirname($this->downloadedFilePath));
 
         try {
             $licenseFile = array($this->projectDir.'/LICENSE');
@@ -391,7 +227,7 @@ class NewCommand extends Command
      *
      * @return NewCommand
      */
-    private function displayInstallationResult()
+    protected function displayInstallationResult()
     {
         if (empty($this->requirementsErrors)) {
             $this->output->writeln(sprintf(
@@ -434,31 +270,12 @@ class NewCommand extends Command
     }
 
     /**
-     * Checks if environment meets symfony requirements
-     *
-     * @return NewCommand
-     */
-    private function checkSymfonyRequirements()
-    {
-        require $this->projectDir.'/app/SymfonyRequirements.php';
-        $symfonyRequirements = new \SymfonyRequirements();
-        $this->requirementsErrors = array();
-        foreach ($symfonyRequirements->getRequirements() as $req) {
-            if ($helpText = $this->getErrorMessage($req)) {
-                $this->requirementsErrors[] = $helpText;
-            }
-        }
-
-        return $this;
-    }
-
-    /**
      * Updates the Symfony parameters.yml file to replace default configuration
      * values with better generated values.
      *
      * @return NewCommand
      */
-    private function updateParameters()
+    protected function updateParameters()
     {
         $filename = $this->projectDir.'/app/config/parameters.yml';
 
@@ -486,7 +303,7 @@ class NewCommand extends Command
      *
      * @return NewCommand
      */
-    private function updateComposerJson()
+    protected function updateComposerJson()
     {
         $filename = $this->projectDir.'/composer.json';
 
@@ -521,84 +338,12 @@ class NewCommand extends Command
     }
 
     /**
-     * Creates the appropriate .gitignore file for a Symfony project.
-     *
-     * @return NewCommand
-     */
-    private function createGitIgnore()
-    {
-        $gitIgnoreEntries = array(
-            '/app/bootstrap.php.cache',
-            '/app/cache/*',
-            '!app/cache/.gitkeep',
-            '/app/config/parameters.yml',
-            '/app/logs/*',
-            '!app/logs/.gitkeep',
-            '/app/phpunit.xml',
-            '/bin/',
-            '/composer.phar',
-            '/vendor/',
-            '/web/bundles/',
-        );
-
-        try {
-            $this->fs->dumpFile($this->projectDir.'/.gitignore', implode("\n", $gitIgnoreEntries)."\n");
-        } catch (\Exception $e) {
-            // don't throw an exception in case the .gitignore file cannot be created,
-            // because this is just an enhancement, not something mandatory for the project
-        }
-
-        return $this;
-    }
-
-    /**
-     * Utility method to show the number of bytes in a readable format.
-     *
-     * @param int     $bytes The number of bytes to format
-     *
-     * @return string The human readable string of bytes (e.g. 4.32MB)
-     */
-    private function formatSize($bytes)
-    {
-        $units = array('B', 'KB', 'MB', 'GB', 'TB');
-
-        $bytes = max($bytes, 0);
-        $pow = $bytes ? floor(log($bytes, 1024)) : 0;
-        $pow = min($pow, count($units) - 1);
-
-        $bytes /= pow(1024, $pow);
-
-        return number_format($bytes, 2).' '.$units[$pow];
-    }
-
-    /**
-     * Formats the error message contained in the given Requirement item
-     * using the optional line length provided.
-     *
-     * @param \Requirement $requirement The Symfony requirements
-     * @param int          $lineSize    The maximum line length
-     *
-     * @return string
-     */
-    private function getErrorMessage(\Requirement $requirement, $lineSize = 70)
-    {
-        if ($requirement->isFulfilled()) {
-            return;
-        }
-
-        $errorMessage  = wordwrap($requirement->getTestMessage(), $lineSize - 3, PHP_EOL.'   ').PHP_EOL;
-        $errorMessage .= '   > '.wordwrap($requirement->getHelpText(), $lineSize - 5, PHP_EOL.'   > ').PHP_EOL;
-
-        return $errorMessage;
-    }
-
-    /**
      * Returns the full Symfony version number of the project by getting
      * it from the composer.lock file.
      *
      * @return string
      */
-    private function getInstalledSymfonyVersion()
+    protected function getInstalledSymfonyVersion()
     {
         $composer = json_decode(file_get_contents($this->projectDir.'/composer.lock'), true);
 
@@ -614,26 +359,12 @@ class NewCommand extends Command
     }
 
     /**
-     * Generates a good random value for Symfony's 'secret' option
-     *
-     * @return string
-     */
-    private function generateRandomSecret()
-    {
-        if (function_exists('openssl_random_pseudo_bytes')) {
-            return hash('sha1', openssl_random_pseudo_bytes(23));
-        }
-
-        return hash('sha1', uniqid(mt_rand(), true));
-    }
-
-    /**
      * Generates a good Composer project name based on the application name
      * and on the user name.
      *
      * @return string
      */
-    private function generateComposerProjectName()
+    protected function generateComposerProjectName()
     {
         $name = preg_replace('{(?:([a-z])([A-Z])|([A-Z])([A-Z][a-z]))}', '\\1\\3-\\2\\4', $this->projectName);
         $name = strtolower($name);
@@ -650,41 +381,5 @@ class NewCommand extends Command
         }
 
         return $name;
-    }
-
-    /**
-     * Returns the executed command.
-     *
-     * @return string
-     */
-    private function getExecutedCommand()
-    {
-        $version = '';
-        if ('latest' !== $this->version) {
-            $version = $this->version;
-        }
-
-        $pathDirs = explode(PATH_SEPARATOR, $_SERVER['PATH']);
-        $executedCommand = $_SERVER['PHP_SELF'];
-        $executedCommandDir = dirname($executedCommand);
-
-        if (in_array($executedCommandDir, $pathDirs)) {
-            $executedCommand = basename($executedCommand);
-        }
-
-        return sprintf('%s new %s %s', $executedCommand, $this->projectName, $version);
-    }
-
-    /**
-     * Checks whether the given directory is empty or not.
-     *
-     * @param  string  $dir the path of the directory to check
-     * @return bool
-     */
-    private function isEmptyDirectory($dir)
-    {
-        // glob() cannot be used because it doesn't take into account hidden files
-        // scandir() returns '.'  and '..'  for an empty dir
-        return 2 === count(scandir($dir.'/'));
     }
 }

--- a/symfony
+++ b/symfony
@@ -23,6 +23,7 @@ $appVersion = '1.0.1-DEV';
 $app = new Symfony\Component\Console\Application('Symfony Installer', $appVersion);
 $app->add(new Symfony\Installer\AboutCommand($appVersion));
 $app->add(new Symfony\Installer\NewCommand());
+$app->add(new Symfony\Installer\DemoCommand());
 $app->add(new Symfony\Installer\SelfUpdateCommand());
 
 $app->setDefaultCommand('about');


### PR DESCRIPTION
This is a WIP and early release of the new `symfony demo` command. The general idea around this command is the following:

  * Soon the `AcmeDemoBundle` will be gone forever.
  * The Symfony Standard Edition (and therefore, the `symfony new` command) will always give you a clean and empty Symfony application.
  * We'll publish a complete Symfony demo application that combines what we did for the Best Practices book (and which wasn't released) and the current AcmeDemoBundle. This will be a real application using `AppBundle` and all the best practices. No more Acme or Demo.
  * If you are new to Symfony and want to test it ... install the Symfony Installer in 1 minute and execute the `symfony demo` command. In 10 seconds you'll have a full-featured Symfony application ready to test.

And here are some comments regarding this command:

  * For now it doesn't download anything because the `Symfony_Demo` package doesn't exist yet.
  * This command **must** be as simple as possible (remember that it will be used by newcomers that just want to test-drive Symfony quickly and easily). That's why we don't allow to select the Symfony version (it will always be the most recent one). And we also don't allow to select the directory where the demo project is installed (it will be installed in `getcwd().'symfony_demo/'`)

And here it is the `demo` command in action:

![symfony_demo_command](https://cloud.githubusercontent.com/assets/73419/6738237/089d80d6-ce71-11e4-9723-efb9592f5bec.png)
