### PR TITLE
fix handling of missing patch version

### DIFF
--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Installer;
 
+use GuzzleHttp\Client;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -53,7 +54,6 @@ class NewCommand extends DownloadCommand
         $this->projectDir = $this->fs->isAbsolutePath($directory) ? $directory : getcwd().DIRECTORY_SEPARATOR.$directory;
         $this->projectName = basename($directory);
         $this->version = trim($input->getArgument('version'));
-        $this->remoteFileUrl = 'http://symfony.com/download?v=Symfony_Standard_Vendors_'.$this->version;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -62,6 +62,7 @@ class NewCommand extends DownloadCommand
             $this
                 ->checkProjectName()
                 ->checkSymfonyVersionIsInstallable()
+                ->initializeRemoteFileUrl()
                 ->download()
                 ->extract()
                 ->cleanUp()
@@ -381,5 +382,17 @@ class NewCommand extends DownloadCommand
         }
 
         return $name;
+    }
+
+    /**
+     * Builds the URL of the archive to download based on the validated version number.
+     *
+     * @return NewCommand
+     */
+    private function initializeRemoteFileUrl()
+    {
+        $this->remoteFileUrl = 'http://symfony.com/download?v=Symfony_Standard_Vendors_'.$this->version;
+
+        return $this;
     }
 }


### PR DESCRIPTION
When the user tried to install the Symfony Standard Edition with just
specifying the minor version (like `symfony new blog 2.3`), the
installer failed for two reasons:

* The `use` statement for the `Client` class was missing when it was
  used to download the list of available versions from symfony.com.
* The URL from where the archive should be downloaded was build before
  the patch version was evaluated. Therefore, the archive of the actual
  Symfony version to be installed could not be found (it was tried to
  download an archive for `2.3` while the archive actually had to be
  referenced for `2.3.26`).

This fixes #119.