### PR TITLE
set PATH environment variable for Windows

### DIFF
--- a/symfony
+++ b/symfony
@@ -20,6 +20,11 @@ require file_exists(__DIR__.'/vendor/autoload.php')
 
 $appVersion = '1.0.3-DEV';
 
+// Windows uses Path instead of PATH
+if (!isset($_SERVER['PATH']) && isset($_SERVER['Path'])) {
+    $_SERVER['PATH'] = $_SERVER['Path'];
+}
+
 $app = new Symfony\Component\Console\Application('Symfony Installer', $appVersion);
 $app->add(new Symfony\Installer\AboutCommand($appVersion));
 $app->add(new Symfony\Installer\NewCommand());


### PR DESCRIPTION
Windows uses Path instead of PATH which causes a notice for the about and download command.