### PR TITLE
Add previous exception for some 'unknown errors'

### DIFF
--- a/src/Symfony/Installer/DownloadCommand.php
+++ b/src/Symfony/Installer/DownloadCommand.php
@@ -135,7 +135,7 @@ abstract class DownloadCommand extends Command
                     "There was an error downloading %s from symfony.com server:\n%s",
                     $this->getDownloadedApplicationType(),
                     $e->getMessage()
-                ));
+                ), null, $e);
             }
         }
 
@@ -192,7 +192,7 @@ abstract class DownloadCommand extends Command
                 "To solve this issue, check the permissions of the %s directory and\n".
                 "try executing this command again:\n%s",
                 $this->getDownloadedApplicationType(), getcwd(), $this->getExecutedCommand()
-            ));
+            ), null, $e);
         }
 
         if (!$extractionSucceeded) {


### PR DESCRIPTION
At the moment, we don't have that many clues when people can't install Symfony and when we can't guess what is the problem with the backtrace.

This PR allows debugging easier, especially when Distill does throw an exception.
 
This is related to #129 