### PR TITLE
Use SSL everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ This step is only needed the first time you use the installer:
 ### Linux and Mac OS X
 
 ```bash
-$ sudo curl -LsS http://symfony.com/installer -o /usr/local/bin/symfony
+$ sudo curl -LsS https://symfony.com/installer -o /usr/local/bin/symfony
 $ sudo chmod a+x /usr/local/bin/symfony
 ```
 
 ### Windows
 
 ```bash
-c:\> php -r "readfile('http://symfony.com/installer');" > symfony
+c:\> php -r "readfile('https://symfony.com/installer');" > symfony
 ```
 
 Move the downloaded `symfony` file to your projects directory and execute

--- a/src/Symfony/Installer/DemoCommand.php
+++ b/src/Symfony/Installer/DemoCommand.php
@@ -129,6 +129,6 @@ class DemoCommand extends DownloadCommand
 
     protected function getRemoteFileUrl()
     {
-        return 'http://symfony.com/download?v=Symfony_Demo';
+        return 'https://symfony.com/download?v=Symfony_Demo';
     }
 }

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -131,7 +131,7 @@ class NewCommand extends DownloadCommand
             // Check if we have a minor version in order to retrieve the last patch from symfony.com
 
             $client = $this->getGuzzleClient();
-            $versionsList = $client->get('http://symfony.com/versions.json')->json();
+            $versionsList = $client->get('https://symfony.com/versions.json')->json();
 
             if ($versionsList && isset($versionsList[$this->version])) {
                 // Get the latest patch of the minor version the user asked
@@ -253,7 +253,7 @@ class NewCommand extends DownloadCommand
             "    * Run your application:\n".
             "        1. Execute the <comment>php app/console server:run</comment> command.\n".
             "        2. Browse to the <comment>http://localhost:8000</comment> URL.\n\n".
-            "    * Read the documentation at <comment>http://symfony.com/doc</comment>\n",
+            "    * Read the documentation at <comment>https://symfony.com/doc</comment>\n",
             $this->projectDir
         ));
 
@@ -400,6 +400,6 @@ class NewCommand extends DownloadCommand
 
     protected function getRemoteFileUrl()
     {
-        return 'http://symfony.com/download?v=Symfony_Standard_Vendors_'.$this->version;
+        return 'https://symfony.com/download?v=Symfony_Standard_Vendors_'.$this->version;
     }
 }

--- a/src/Symfony/Installer/SelfUpdateCommand.php
+++ b/src/Symfony/Installer/SelfUpdateCommand.php
@@ -75,7 +75,7 @@ class SelfUpdateCommand extends Command
         $this->fs = new Filesystem();
         $this->output = $output;
 
-        $this->remoteInstallerFile = 'http://symfony.com/installer';
+        $this->remoteInstallerFile = 'https://symfony.com/installer';
         $this->currentInstallerFile = realpath($_SERVER['argv'][0]) ?: $_SERVER['argv'][0];
         $this->tempDir = sys_get_temp_dir();
         $this->currentInstallerBackupFile = basename($this->currentInstallerFile, '.phar').'-backup.phar';
@@ -122,7 +122,7 @@ class SelfUpdateCommand extends Command
         $isUpdated = false;
         $localVersion = $this->getApplication()->getVersion();
 
-        if (false === $remoteVersion = @file_get_contents('http://get.sensiolabs.org/symfony.version')) {
+        if (false === $remoteVersion = @file_get_contents('https://get.sensiolabs.org/symfony.version')) {
             throw new \RuntimeException('The new version of the Symfony Installer couldn\'t be downloaded from the server.');
         }
 


### PR DESCRIPTION
`symfony.com` enabled SSL recently, so we should switch to `https://` everywhere.