### PR TITLE
fix uppercase usernames

### DIFF
--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -380,17 +380,36 @@ class NewCommand extends DownloadCommand
         $name = strtolower($name);
 
         if (!empty($_SERVER['USERNAME'])) {
-            $name = $_SERVER['USERNAME'].'/'.$name;
+            $name = $this->fixComposerVendorName($_SERVER['USERNAME']).'/'.$name;
         } elseif (true === extension_loaded('posix') && $user = posix_getpwuid(posix_getuid())) {
-            $name = $user['name'].'/'.$name;
+            $name = $this->fixComposerVendorName($user['name']).'/'.$name;
         } elseif (get_current_user()) {
-            $name = get_current_user().'/'.$name;
+            $name = $this->fixComposerVendorName(get_current_user()).'/'.$name;
         } else {
             // package names must be in the format foo/bar
             $name = $name.'/'.$name;
         }
 
         return $name;
+    }
+    
+    /**
+     * Transforms uppercase user names to dash-separated usernames:
+     * FooBar -> foo-bar
+     * 
+     * @param string $name The name to transform
+     * 
+     * @return string
+     */
+    private function fixComposerVendorName($name)
+    {
+        return strtolower(
+            preg_replace(
+                array('/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'),
+                array('\\1-\\2', '\\1-\\2'),
+                strtr($name, '-', '.')
+            )
+        );
     }
 
     protected function getDownloadedApplicationType()

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -376,21 +376,20 @@ class NewCommand extends DownloadCommand
      */
     protected function generateComposerProjectName()
     {
-        $name = preg_replace('{(?:([a-z])([A-Z])|([A-Z])([A-Z][a-z]))}', '\\1\\3-\\2\\4', $this->projectName);
-        $name = strtolower($name);
+        $name = $this->projectName;
 
         if (!empty($_SERVER['USERNAME'])) {
-            $name = $this->fixComposerVendorName($_SERVER['USERNAME']).'/'.$name;
+            $name = $_SERVER['USERNAME'].'/'.$name;
         } elseif (true === extension_loaded('posix') && $user = posix_getpwuid(posix_getuid())) {
-            $name = $this->fixComposerVendorName($user['name']).'/'.$name;
+            $name = $user['name'].'/'.$name;
         } elseif (get_current_user()) {
-            $name = $this->fixComposerVendorName(get_current_user()).'/'.$name;
+            $name = get_current_user().'/'.$name;
         } else {
             // package names must be in the format foo/bar
             $name = $name.'/'.$name;
         }
 
-        return $name;
+        return $this->fixComposerVendorName($name);
     }
     
     /**


### PR DESCRIPTION
uppercase usernames will cause issues when submitting applications to packagist.

This bugfix transforms uppercase usernames like Ma27 to ma27 and all uppercase letters will be transformed to dashes