### PR TITLE
Add tip to create windows executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ it as follows:
 c:\> php symfony
 ```
 
+> **TIP**: Create a Global Executable
+>
+> `c:\> (echo @ECHO OFF & echo php "%~dp0symfony" %*) > symfony.bat`
+>
+> You can then move `symfony` and `symfony.bat` to a location in your path,
+> allowing you to run `symfony` from anywhere
+
+
 Using the installer
 -------------------
 


### PR DESCRIPTION
Updated README with instructions to generate a windows `symfony.bat` file, to allow for running the symfony installer globally.