### PR TITLE
Allow to execute the `symfony demo` command repeatedly

### DIFF
--- a/src/Symfony/Installer/DemoCommand.php
+++ b/src/Symfony/Installer/DemoCommand.php
@@ -30,7 +30,7 @@ class DemoCommand extends DownloadCommand
     {
         $this
             ->setName('demo')
-            ->addArgument('directory', InputArgument::OPTIONAL, 'Directory where the new project will be created.', 'symfony_demo')
+            ->addArgument('directory', InputArgument::OPTIONAL, 'Directory where the new project will be created.')
             ->setDescription('Creates a demo Symfony project.')
         ;
     }


### PR DESCRIPTION
If `-> addArgument()` provides a default value for the `directory` argument, then the `!$input->getArgument('directory')` instruction will never be `true`. The result is that you cannot execute the `symfony demo` command repeatedly as you could in the previous versions:

![symfony_demo](https://cloud.githubusercontent.com/assets/73419/8076829/b62051c8-0f50-11e5-9d58-eb9ca33735d0.png)
