### PR TITLE
Don't use HHVM to run box as it gets rejected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,14 @@ matrix:
 
 before_install:
   - composer self-update
-  - curl -LSs https://box-project.github.io/box2/installer.php | php
+  # always use php 5.6 to run Box to avoid issues on HHVM
+  - curl -LSs https://box-project.github.io/box2/installer.php | ~/.phpenv/versions/5.6/bin/php
   - mv box.phar box
   - chmod 755 box
 
 install:
   - composer install
-  - php box build
+  - ~/.phpenv/versions/5.6/bin/php box build
 
 script:
   - phpunit


### PR DESCRIPTION
This is an attempt at making the testsuite run on HHVM. We don't really care about running Box on each version, as we are not testing Box itself (the version being downloaded will not have been built with the same PHP version than the one you use when running the installer anyway)