### PR TITLE
Improve the installation of -dev and -BETA versions

### DIFF
--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -171,6 +171,11 @@ class NewCommand extends DownloadCommand
             ));
         }
 
+        // warn the user when downloading an unstable version
+        if (preg_match('/^.*\-(dev|BETA)\d*$/', $this->version)) {
+            $this->output->writeln("\n <bg=red> WARNING </> You are downloading an unstable Symfony version.");
+        }
+
         return $this;
     }
 

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -113,7 +113,7 @@ class NewCommand extends DownloadCommand
 
         // validate semver syntax
         if (!preg_match('/^2\.\d(?:\.\d{1,2})?(-(dev|BETA)\d*)?$/', $this->version)) {
-            throw new \RuntimeException('The Symfony version should be 2.N or 2.N.M, where N = 0..9 and M = 0..99.');
+            throw new \RuntimeException('The Symfony version should be 2.N or 2.N.M, where N = 0..9 and M = 0..99. The special "-dev" or "-BETA" suffixes are also supported.');
         }
 
         if (preg_match('/^2\.\d$/', $this->version)) {
@@ -171,8 +171,20 @@ class NewCommand extends DownloadCommand
             ));
         }
 
+        // "-dev" versions are not supported because Symfony doesn't provide packages for them
+        if (preg_match('/^.*\-dev$/', $this->version)) {
+            throw new \RuntimeException(sprintf(
+                "The selected version (%s) cannot be installed because it hasn't\n".
+                "been published as a package yet. Read the following article for\n".
+                "an alternative installation method:\n\n".
+                "> How to Install or Upgrade to the Latest, Unreleased Symfony Version\n".
+                "> http://symfony.com/doc/current/cookbook/install/unstable_versions.html",
+                $this->version
+            ));
+        }
+
         // warn the user when downloading an unstable version
-        if (preg_match('/^.*\-(dev|BETA)\d*$/', $this->version)) {
+        if (preg_match('/^.*\-BETA\d*$/', $this->version)) {
             $this->output->writeln("\n <bg=red> WARNING </> You are downloading an unstable Symfony version.");
         }
 

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -111,8 +111,8 @@ class NewCommand extends DownloadCommand
         }
 
         // validate semver syntax
-        if (!preg_match('/^2\.\d(?:\.\d{1,2})?(-(dev|BETA\d*))?$/i', $this->version)) {
-            throw new \RuntimeException('The Symfony version should be 2.N or 2.N.M, where N = 0..9 and M = 0..99. The special "-dev" or "-BETA" suffixes are also supported.');
+        if (!preg_match('/^2\.\d(?:\.\d{1,2})?(?:-(?:dev|BETA\d*|RC\d*))?$/i', $this->version)) {
+            throw new \RuntimeException('The Symfony version should be 2.N or 2.N.M, where N = 0..9 and M = 0..99. The special "-dev" "-BETA" and "-RC" suffixes are also supported.');
         }
 
         if (preg_match('/^2\.\d$/', $this->version)) {
@@ -183,8 +183,10 @@ class NewCommand extends DownloadCommand
         }
 
         // warn the user when downloading an unstable version
-        if (preg_match('/^.*\-BETA\d*$/i', $this->version)) {
+        if (preg_match('/^.*\-(BETA|RC)\d*$/i', $this->version)) {
             $this->output->writeln("\n <bg=red> WARNING </> You are downloading an unstable Symfony version.");
+            // versions provided by the download server are case sensitive
+            $this->version = strtoupper($this->version);
         }
 
         return $this;

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -111,7 +111,7 @@ class NewCommand extends DownloadCommand
         }
 
         // validate semver syntax
-        if (!preg_match('/^2\.\d(?:\.\d{1,2})?(-(dev|BETA\d*))?$/', $this->version)) {
+        if (!preg_match('/^2\.\d(?:\.\d{1,2})?(-(dev|BETA\d*))?$/i', $this->version)) {
             throw new \RuntimeException('The Symfony version should be 2.N or 2.N.M, where N = 0..9 and M = 0..99. The special "-dev" or "-BETA" suffixes are also supported.');
         }
 
@@ -171,7 +171,7 @@ class NewCommand extends DownloadCommand
         }
 
         // "-dev" versions are not supported because Symfony doesn't provide packages for them
-        if (preg_match('/^.*\-dev$/', $this->version)) {
+        if (preg_match('/^.*\-dev$/i', $this->version)) {
             throw new \RuntimeException(sprintf(
                 "The selected version (%s) cannot be installed because it hasn't\n".
                 "been published as a package yet. Read the following article for\n".
@@ -183,7 +183,7 @@ class NewCommand extends DownloadCommand
         }
 
         // warn the user when downloading an unstable version
-        if (preg_match('/^.*\-BETA\d*$/', $this->version)) {
+        if (preg_match('/^.*\-BETA\d*$/i', $this->version)) {
             $this->output->writeln("\n <bg=red> WARNING </> You are downloading an unstable Symfony version.");
         }
 

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -70,7 +70,7 @@ class NewCommand extends DownloadCommand
             aborted:
 
             $output->writeln('');
-            $output->writeln('<error>Aborting download and cleaning up temporary directories.</error>');
+            $output->writeln('<error>Aborting download and cleaning up temporary directories.</>');
 
             $this->cleanUp();
 
@@ -105,11 +105,9 @@ class NewCommand extends DownloadCommand
      */
     protected function checkSymfonyVersionIsInstallable()
     {
-        // Available at the moment of installing Symfony with this installer.
         // 'latest' is a special version name that refers to the latest stable version
         // 'lts' is a special version name that refers to the current long term support version
-        // 'dev' is a special version name that refers to the current development version
-        if (in_array($this->version, array('latest', 'lts', 'dev'))) {
+        if (in_array($this->version, array('latest', 'lts'))) {
             return $this;
         }
 
@@ -171,31 +169,6 @@ class NewCommand extends DownloadCommand
                 'composer create-project symfony/framework-standard-edition %s %s',
                 $this->version, $this->projectDir, $this->version
             ));
-        }
-
-        return $this;
-    }
-
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
-     * @return NewCommand
-     *
-     * @throws AbortException If the user wants to stop the download process in case of dev/BETA versions
-     */
-    protected function askUserConfirmation(InputInterface $input, OutputInterface $output)
-    {
-        if (preg_match('/^(\d\.\d)(\.\d{1,2})?-(dev|BETA)\d*$/', $this->version)) {
-            $helper = $this->getHelper('question');
-            $question = new ConfirmationQuestion(
-                sprintf('<question>You are trying to install an unstable version (%s). Do you confirm this action? [y/n]</question>', $this->version),
-                false
-            );
-
-            if (!$helper->ask($input, $output, $question)) {
-                throw new AbortException();
-            }
         }
 
         return $this;

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -111,7 +111,7 @@ class NewCommand extends DownloadCommand
         }
 
         // validate semver syntax
-        if (!preg_match('/^2\.\d(?:\.\d{1,2})?|2\.\d(?:-(?:dev|BETA\d*|RC\d*))$/i', $this->version)) {
+        if (!preg_match('/^2\.\d(?:\.\d{1,2})?(?:-(?:dev|BETA\d*|RC\d*))?$/i', $this->version)) {
             throw new \RuntimeException('The Symfony version must be 2.N or 2.N.M (where N and M are positive integers). The special "-dev", "-BETA" and "-RC" versions are also supported.');
         }
 

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Installer\Exception\AbortException;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * This command creates new Symfony projects for the given Symfony version.
@@ -69,7 +70,7 @@ class NewCommand extends DownloadCommand
             aborted:
 
             $output->writeln('');
-            $output->writeln('<error>Aborting download and cleaning up temporary directories.</>');
+            $output->writeln('<error>Aborting download and cleaning up temporary directories.</error>');
 
             $this->cleanUp();
 
@@ -104,20 +105,17 @@ class NewCommand extends DownloadCommand
      */
     protected function checkSymfonyVersionIsInstallable()
     {
+        // Available at the moment of installing Symfony with this installer.
         // 'latest' is a special version name that refers to the latest stable version
-        // available at the moment of installing Symfony
-        if ('latest' === $this->version) {
-            return $this;
-        }
-
         // 'lts' is a special version name that refers to the current long term support version
-        if ('lts' === $this->version) {
+        // 'dev' is a special version name that refers to the current development version
+        if (in_array($this->version, array('latest', 'lts', 'dev'))) {
             return $this;
         }
 
         // validate semver syntax
-        if (!preg_match('/^2\.\d(?:\.\d{1,2})?$/', $this->version)) {
-            throw new \RuntimeException('The Symfony version should be 2.N or 2.N.M, where N = 0..9 and M = 0..99');
+        if (!preg_match('/^2\.\d(?:\.\d{1,2})?(-(dev|BETA)\d*)?$/', $this->version)) {
+            throw new \RuntimeException('The Symfony version should be 2.N or 2.N.M, where N = 0..9 and M = 0..99.');
         }
 
         if (preg_match('/^2\.\d$/', $this->version)) {
@@ -173,6 +171,31 @@ class NewCommand extends DownloadCommand
                 'composer create-project symfony/framework-standard-edition %s %s',
                 $this->version, $this->projectDir, $this->version
             ));
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return NewCommand
+     *
+     * @throws AbortException If the user wants to stop the download process in case of dev/BETA versions
+     */
+    protected function askUserConfirmation(InputInterface $input, OutputInterface $output)
+    {
+        if (preg_match('/^(\d\.\d)(\.\d{1,2})?-(dev|BETA)\d*$/', $this->version)) {
+            $helper = $this->getHelper('question');
+            $question = new ConfirmationQuestion(
+                sprintf('<question>You are trying to install an unstable version (%s). Do you confirm this action? [y/n]</question>', $this->version),
+                false
+            );
+
+            if (!$helper->ask($input, $output, $question)) {
+                throw new AbortException();
+            }
         }
 
         return $this;

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -111,7 +111,7 @@ class NewCommand extends DownloadCommand
         }
 
         // validate semver syntax
-        if (!preg_match('/^2\.\d(?:\.\d{1,2})?(-(dev|BETA)\d*)?$/', $this->version)) {
+        if (!preg_match('/^2\.\d(?:\.\d{1,2})?(-(dev|BETA\d*))?$/', $this->version)) {
             throw new \RuntimeException('The Symfony version should be 2.N or 2.N.M, where N = 0..9 and M = 0..99. The special "-dev" or "-BETA" suffixes are also supported.');
         }
 

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -111,8 +111,8 @@ class NewCommand extends DownloadCommand
         }
 
         // validate semver syntax
-        if (!preg_match('/^2\.\d(?:\.\d{1,2})?(?:-(?:dev|BETA\d*|RC\d*))?$/i', $this->version)) {
-            throw new \RuntimeException('The Symfony version should be 2.N or 2.N.M, where N = 0..9 and M = 0..99. The special "-dev" "-BETA" and "-RC" suffixes are also supported.');
+        if (!preg_match('/^2\.\d(?:\.\d{1,2})?|2\.\d(?:-(?:dev|BETA\d*|RC\d*))$/i', $this->version)) {
+            throw new \RuntimeException('The Symfony version must be 2.N or 2.N.M (where N and M are positive integers). The special "-dev", "-BETA" and "-RC" versions are also supported.');
         }
 
         if (preg_match('/^2\.\d$/', $this->version)) {

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Installer\Exception\AbortException;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * This command creates new Symfony projects for the given Symfony version.
@@ -178,7 +177,7 @@ class NewCommand extends DownloadCommand
                 "been published as a package yet. Read the following article for\n".
                 "an alternative installation method:\n\n".
                 "> How to Install or Upgrade to the Latest, Unreleased Symfony Version\n".
-                "> http://symfony.com/doc/current/cookbook/install/unstable_versions.html",
+                '> http://symfony.com/doc/current/cookbook/install/unstable_versions.html',
                 $this->version
             ));
         }

--- a/tests/Symfony/Installer/Tests/IntegrationTest.php
+++ b/tests/Symfony/Installer/Tests/IntegrationTest.php
@@ -108,7 +108,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
             ),
 
             array(
-                '2.7-BETA1',
+                '2.7.0-BETA1',
                 '/.*Symfony 2\.7\.0\-BETA1 was successfully installed.*/',
                 '/Symfony version 2\.7\-BETA1 - app\/dev\/debug/',
             ),

--- a/tests/Symfony/Installer/Tests/IntegrationTest.php
+++ b/tests/Symfony/Installer/Tests/IntegrationTest.php
@@ -110,7 +110,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
             array(
                 '2.7.0-BETA1',
                 '/.*Symfony 2\.7\.0\-BETA1 was successfully installed.*/',
-                '/Symfony version 2\.7\-BETA1 - app\/dev\/debug/',
+                '/Symfony version 2\.7\.0\-BETA1 - app\/dev\/debug/',
             ),
         );
     }

--- a/tests/Symfony/Installer/Tests/IntegrationTest.php
+++ b/tests/Symfony/Installer/Tests/IntegrationTest.php
@@ -109,14 +109,8 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
 
             array(
                 '2.7-BETA1',
-                '/.*Symfony 2\.7\-BETA1 was successfully installed.*/',
+                '/.*Symfony 2\.7\.0\-BETA1 was successfully installed.*/',
                 '/Symfony version 2\.7\-BETA1 - app\/dev\/debug/',
-            ),
-
-            array(
-                '2.7-RC1',
-                '/.*Symfony 2\.7\-RC1 was successfully installed.*/',
-                '/Symfony version 2\.7\-RC1 - app\/dev\/debug/',
             ),
         );
     }

--- a/tests/Symfony/Installer/Tests/IntegrationTest.php
+++ b/tests/Symfony/Installer/Tests/IntegrationTest.php
@@ -106,6 +106,18 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
                 '/.*Symfony 2\.5\.6 was successfully installed.*/',
                 '/Symfony version 2\.5\.6 - app\/dev\/debug/',
             ),
+
+            array(
+                '2.7-BETA1',
+                '/.*Symfony 2\.7\-BETA1 was successfully installed.*/',
+                '/Symfony version 2\.7\-BETA1 - app\/dev\/debug/',
+            ),
+
+            array(
+                '2.7-RC1',
+                '/.*Symfony 2\.7\-RC1 was successfully installed.*/',
+                '/Symfony version 2\.7\-RC1 - app\/dev\/debug/',
+            ),
         );
     }
 }


### PR DESCRIPTION
This finishes #159, which is related to #144 and #143.

The new behavior of the installer:

1) When installing a regular Symfony version, nothing changes from the previous installer.

2) When you install a `beta` version, you see a warning message:

![symfony-unstable-warning](https://cloud.githubusercontent.com/assets/73419/9811676/f14b6d02-5878-11e5-9220-301fcb671c8c.png)

3) When you try to install a `dev` version, you get a better error message and a link to the article that will solve your problem:

![symfony-dev-version](https://cloud.githubusercontent.com/assets/73419/9811642/c0bdc194-5878-11e5-9ee8-9af5e194f80b.png)
