### PR TITLE
Improved the way we detect newer versions

### DIFF
--- a/src/Symfony/Installer/SelfUpdateCommand.php
+++ b/src/Symfony/Installer/SelfUpdateCommand.php
@@ -126,7 +126,7 @@ class SelfUpdateCommand extends Command
             throw new \RuntimeException('The new version of the Symfony Installer couldn\'t be downloaded from the server.');
         }
 
-        if ($localVersion === $remoteVersion) {
+        if (1 !== version_compare($remoteVersion, $localVersion)) {
             $this->output->writeln('<info>Symfony Installer is already up to date.</info>');
             $isUpdated = true;
         } else {

--- a/src/Symfony/Installer/SelfUpdateCommand.php
+++ b/src/Symfony/Installer/SelfUpdateCommand.php
@@ -126,7 +126,7 @@ class SelfUpdateCommand extends Command
             throw new \RuntimeException('The new version of the Symfony Installer couldn\'t be downloaded from the server.');
         }
 
-        if (1 !== version_compare($remoteVersion, $localVersion)) {
+        if (version_compare($localVersion, $remoteVersion, '>=')) {
             $this->output->writeln('<info>Symfony Installer is already up to date.</info>');
             $isUpdated = true;
         } else {


### PR DESCRIPTION
Due to some infrastructure changes, we could end up with the unusual case where your installer detects a previous version of the installer and "updates" to it. Instead of checking if our local version is different from the remote version, we now strictly check if our version is lower than the remote one.