### PR TITLE
Fix lowercase issue with unicode characters

### DIFF
--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -397,8 +397,8 @@ class NewCommand extends DownloadCommand
     {
         return strtolower(
             preg_replace(
-                array('/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'),
-                array('\\1-\\2', '\\1-\\2'),
+                array('~[^\w.-]~iu', '~([A-Z]+)([A-Z][a-z])~u', '~([a-z\d])([A-Z])~u'),
+                array('', '\\1-\\2', '\\1-\\2'),
                 strtr($name, '-', '.')
             )
         );


### PR DESCRIPTION
As of #190, @cccm62 pointed the fact that using `symfony new` with a name containing unicode characters, like `symfony new génial`, the package name were converted to `gã©nial` due to the lack of utf-8 support in `strtolower`. 
 
This is why I added the `u` flag to `preg_replace` to support unicode, added the `mb_strtolower` function if it exists, and added a workaround if not.
 
Does it sound correct?