### PR TITLE
Fix Symfony3 is now the latest release

### DIFF
--- a/src/Symfony/Installer/DownloadCommand.php
+++ b/src/Symfony/Installer/DownloadCommand.php
@@ -468,7 +468,7 @@ abstract class DownloadCommand extends Command
      */
     protected function isSymfony3()
     {
-        return $this->version && '3' === $this->version[0];
+        return '3' === $this->version[0] || 'latest' === $this->version;
     }
 
     private function enableSignalHandler()


### PR DESCRIPTION
Symfony 3 is now the latest release. :tada: 

Fix the following issue:

```bash
symfony new test

 Downloading Symfony...

    4.93 MB/4.93 MB ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  100%

 Preparing project...

PHP Warning:  require(/Users/Ogi/test/app/SymfonyRequirements.php): failed to open stream: No such file or directory in phar:///usr/local/bin/symfony/src/Symfony/Installer/DownloadCommand.php on line 265

Warning: require(/Users/Ogi/test/app/SymfonyRequirements.php): failed to open stream: No such file or directory in phar:///usr/local/bin/symfony/src/Symfony/Installer/DownloadCommand.php on line 265
PHP Fatal error:  require(): Failed opening required '/Users/Ogi/test/app/SymfonyRequirements.php' (include_path='.:/usr/local/php5/lib/php') in phar:///usr/local/bin/symfony/src/Symfony/Installer/DownloadCommand.php on line 265

Fatal error: require(): Failed opening required '/Users/Ogi/test/app/SymfonyRequirements.php' (include_path='.:/usr/local/php5/lib/php') in phar:///usr/local/bin/symfony/src/Symfony/Installer/DownloadCommand.php on line 265
```