### PR TITLE
Fix symfony demo uses lts

### DIFF
--- a/src/Symfony/Installer/DemoCommand.php
+++ b/src/Symfony/Installer/DemoCommand.php
@@ -39,6 +39,8 @@ class DemoCommand extends DownloadCommand
     {
         parent::initialize($input, $output);
 
+        $this->version = 'lts';
+
         if (!$input->getArgument('directory')) {
             $this->projectDir = getcwd();
 

--- a/src/Symfony/Installer/DownloadCommand.php
+++ b/src/Symfony/Installer/DownloadCommand.php
@@ -59,7 +59,7 @@ abstract class DownloadCommand extends Command
     /**
      * @var string
      */
-    protected $version;
+    protected $version = 'latest';
 
     /**
      * @var string
@@ -90,8 +90,6 @@ abstract class DownloadCommand extends Command
         $this->fs = new Filesystem();
 
         $this->enableSignalHandler();
-
-        $this->version = $input->hasArgument('version') ? trim($input->getArgument('version')) : 'latest';
     }
 
     /**

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -39,6 +39,7 @@ class NewCommand extends DownloadCommand
         parent::initialize($input, $output);
 
         $directory = rtrim(trim($input->getArgument('directory')), DIRECTORY_SEPARATOR);
+        $this->version = trim($input->getArgument('version'));
         $this->projectDir = $this->fs->isAbsolutePath($directory) ? $directory : getcwd().DIRECTORY_SEPARATOR.$directory;
         $this->projectName = basename($directory);
     }

--- a/tests/Symfony/Installer/Tests/IntegrationTest.php
+++ b/tests/Symfony/Installer/Tests/IntegrationTest.php
@@ -57,7 +57,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Downloading Symfony...', $output);
         $this->assertRegExp($messageRegexp, $output);
 
-        if ('3' === substr($versionToInstall, 0, 1)) {
+        if ('3' === substr($versionToInstall, 0, 1) || '' === $versionToInstall) {
             if (PHP_VERSION_ID < 50500) {
                 $this->markTestSkipped('Symfony 3 requires PHP 5.5.9 or higher.');
             }
@@ -107,14 +107,14 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         return array(
             array(
                 '',
-                '/.*Symfony 2\.7\.\d+ was successfully installed.*/',
-                '/Symfony version 2\.7\.\d+ - app\/dev\/debug/',
+                '/.*Symfony 3\.0\.\d+ was successfully installed.*/',
+                '/Symfony version 3\.0\.\d+ - app\/dev\/debug/',
             ),
 
             array(
                 'lts',
-                '/.*Symfony 2\.7\.\d+ was successfully installed.*/',
-                '/Symfony version 2\.7\.\d+ - app\/dev\/debug/',
+                '/.*Symfony 2\.8\.\d+ was successfully installed.*/',
+                '/Symfony version 2\.8\.\d+ - app\/dev\/debug/',
             ),
 
             array(


### PR DESCRIPTION
- [x] Fix `symfony demo` command
> The demo application still uses LTS (2.7 actually), so the `symfony demo` command also fails ([search for `var/SymfonyRequirements.php`](https://travis-ci.org/symfony/symfony-installer/jobs/94038672#L209)). :/
It's solved by using `lts` as the default version for the `DemoCommand`.

- [x] Fix tests
> This PR also updates tests failures due to the new LTS and latest releases, in order to have everything green again.