### PR TITLE
Intercept and customize error from Guzzle

### DIFF
--- a/src/Symfony/Installer/DownloadCommand.php
+++ b/src/Symfony/Installer/DownloadCommand.php
@@ -19,6 +19,7 @@ use Distill\Strategy\MinimumSize;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Event\ProgressEvent;
+use GuzzleHttp\Utils;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -221,7 +222,15 @@ abstract class DownloadCommand extends Command
             $defaults['debug'] = true;
         }
 
-        return new Client(array('defaults' => $defaults));
+        try {
+            $handler = Utils::getDefaultHandler();
+        } catch (\RuntimeException $e) {
+            throw new \RuntimeException(
+                'The Symfony installer requires the php-curl extension or the allow_url_fopen ini setting.'
+            );
+        }
+
+        return new Client(array('defaults' => $defaults, 'handler' => $handler));
     }
 
     /**


### PR DESCRIPTION
When guzzle is initalized it tries to find a suitable handler to use. If no handler can be found (for example curl) an exception is thrown.

With this change we try to find the handler before creating the client so that we can pass the handler to the client manually.
Doing this, we are able to customize the error message to make it (potentially) less confusing for the users who might have no idea what guzzle is.

The issue was found when looking at PR #200 