### PR TITLE
box build fails with invalid path error

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,5 +1,5 @@
 {
-    "directories": ["src/"],
+    "directories": ["src"],
     "finder": [
         {
             "name": "*.php",


### PR DESCRIPTION
This PR fixes the issue when the `box build` command fails with the following error:

```
$ box build
Building...


  [BadMethodCallException]
  Entry src//Symfony/Installer/AboutCommand.php does not exist and cannot be created: phar error: invalid path "src//Symfony/Installer/AboutCommand.php" contains double slash


build [-c|--configuration CONFIGURATION]
```

The [examples in the box wiki](https://github.com/box-project/box2/wiki/Composer) also uses directory names without the trailing slash.

Tested on this system config:
php: 5.5.29
box: 2.6.1
os: OS X 10.10.5