### PR TITLE
Fixed the SymfonyRequirements check for the demo application

### DIFF
--- a/src/Symfony/Installer/DownloadCommand.php
+++ b/src/Symfony/Installer/DownloadCommand.php
@@ -308,9 +308,12 @@ abstract class DownloadCommand extends Command
      */
     protected function checkSymfonyRequirements()
     {
+        if (null === $requirementsFile = $this->getSymfonyRequirementsFilePath()) {
+            return $this;
+        }
+
         try {
-            $requirementsDir = $this->isSymfony3() ? 'var' : 'app';
-            require $this->projectDir.'/'.$requirementsDir.'/SymfonyRequirements.php';
+            require $requirementsFile;
             $symfonyRequirements = new \SymfonyRequirements();
             $this->requirementsErrors = array();
             foreach ($symfonyRequirements->getRequirements() as $req) {
@@ -323,6 +326,22 @@ abstract class DownloadCommand extends Command
         }
 
         return $this;
+    }
+
+    private function getSymfonyRequirementsFilePath()
+    {
+        $paths = array(
+            $this->projectDir.'/app/SymfonyRequirements.php',
+            $this->projectDir.'/var/SymfonyRequirements.php',
+        );
+
+        foreach ($paths as $path) {
+            if (file_exists($path)) {
+                return $path;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Symfony/Installer/Tests/IntegrationTest.php
+++ b/tests/Symfony/Installer/Tests/IntegrationTest.php
@@ -48,8 +48,8 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('Downloading the Symfony Demo Application', $output);
         $this->assertContains('Symfony Demo Application was successfully installed.', $output);
 
-        $output = $this->runCommand('php app/console --version', $projectDir);
-        $this->assertRegExp('/Symfony version 2\.\d+\.\d+(-DEV)? - app\/dev\/debug/', $output);
+        $output = $this->runCommand('php bin/console --version', $projectDir);
+        $this->assertRegExp('/Symfony version 3\.\d+\.\d+(-DEV)? - app\/dev\/debug/', $output);
 
         $composerConfig = json_decode(file_get_contents($projectDir.'/composer.json'), true);
 

--- a/tests/Symfony/Installer/Tests/IntegrationTest.php
+++ b/tests/Symfony/Installer/Tests/IntegrationTest.php
@@ -41,6 +41,10 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
 
     public function testDemoApplicationInstallation()
     {
+        if (PHP_VERSION_ID < 50500) {
+            $this->markTestSkipped('Symfony 3 requires PHP 5.5.9 or higher.');
+        }
+
         $projectDir = sprintf('%s/my_test_project', sys_get_temp_dir());
         $this->fs->remove($projectDir);
 


### PR DESCRIPTION
The Symfony Demo was upgraded to Symfony 3 yesterday. If you install it, you get this error:

![symfony_demo_error](https://cloud.githubusercontent.com/assets/73419/16355615/9c6e758c-3abc-11e6-819b-528f903f8711.png)

The problem is that the `isSymfony3()` method is not suitable for the demo application. We cannot improve that method to get the Symfony version via the `--version` option because at that point we are about to check the Symfony Requirements to see if the computer can run the demo application.