### PR TITLE
#266 Self update is not detecting the installed version

### DIFF
--- a/src/Symfony/Installer/DownloadCommand.php
+++ b/src/Symfony/Installer/DownloadCommand.php
@@ -65,12 +65,12 @@ abstract class DownloadCommand extends Command
     /**
      * @var string The latest installer version
      */
-    private $latestInstallerVersion;
+    protected $latestInstallerVersion;
 
     /**
      * @var string The version of the local installer being executed
      */
-    private $localInstallerVersion;
+    protected $localInstallerVersion;
 
     /**
      * @var string The path to the downloaded file

--- a/src/Symfony/Installer/SelfUpdateCommand.php
+++ b/src/Symfony/Installer/SelfUpdateCommand.php
@@ -13,7 +13,6 @@ namespace Symfony\Installer;
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Exception\IOException;
 
 /**
@@ -32,11 +31,6 @@ class SelfUpdateCommand extends DownloadCommand
      * @var string The temp dir
      */
     private $tempDir;
-
-    /**
-     * @var string The latest installer version
-     */
-    private $latestInstallerVersion;
 
     /**
      * @var string The URL where the latest installer version can be downloaded
@@ -92,10 +86,7 @@ class SelfUpdateCommand extends DownloadCommand
      */
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
-        $this->fs = new Filesystem();
-        $this->output = $output;
-
-        $this->latestInstallerVersion = $this->getUrlContents(Application::VERSIONS_URL);
+        parent::initialize($input, $output);
         $this->remoteInstallerFile = 'http://symfony.com/installer';
         $this->currentInstallerFile = realpath($_SERVER['argv'][0]) ?: $_SERVER['argv'][0];
         $this->tempDir = sys_get_temp_dir();


### PR DESCRIPTION
When the self-update command is initialized, the current version and latest version of the installer are not initialized.
The code is currently comparing NULL with NULL, which returns true.

By adding the parent::initialize() call, the DownloadCommand set the current and latest version of the installer, and then the version_compare function is actually really comparing the real versions.