### PR TITLE
Declare the Symfony Installer incompatible with 'suhosin' PHP extension

### DIFF
--- a/symfony
+++ b/symfony
@@ -15,13 +15,12 @@ if (PHP_VERSION_ID < 50400) {
 }
 
 if (extension_loaded('suhosin')) {
-    file_put_contents('php://stderr', sprintf(
+    file_put_contents('php://stderr',
         "Symfony Installer is not compatible with the 'suhosin' PHP extension.\n".
         "Disable that extension before running the installer.\n\n".
         "Alternatively, install Symfony manually executing the following command:\n\n".
-        "composer create-project symfony/framework-standard-edition <project-name> <symfony-version>\n\n",
-        PHP_VERSION
-    ));
+        "composer create-project symfony/framework-standard-edition <project-name> <symfony-version>\n\n"
+    );
 
     exit(1);
 }

--- a/symfony
+++ b/symfony
@@ -14,6 +14,18 @@ if (PHP_VERSION_ID < 50400) {
     exit(1);
 }
 
+if (extension_loaded('suhosin')) {
+    file_put_contents('php://stderr', sprintf(
+        "Symfony Installer is not compatible with the 'suhosin' PHP extension.\n".
+        "Disable that extension before running the installer.\n\n".
+        "Alternatively, install Symfony manually executing the following command:\n\n".
+        "composer create-project symfony/framework-standard-edition <project-name> <symfony-version>\n\n",
+        PHP_VERSION
+    ));
+
+    exit(1);
+}
+
 require file_exists(__DIR__.'/vendor/autoload.php')
     ? __DIR__.'/vendor/autoload.php'
     : __DIR__.'/../../autoload.php';


### PR DESCRIPTION
As reported in #264, 'suhosin' causes a lot of problems for the Symfony Installer.