### PR TITLE
Fixed some issues for the self-update command

### DIFF
--- a/src/Symfony/Installer/DownloadCommand.php
+++ b/src/Symfony/Installer/DownloadCommand.php
@@ -520,6 +520,7 @@ abstract class DownloadCommand extends Command
         }
 
         $commandName = $this->getName();
+        $commandArguments = '';
 
         if ('new' === $commandName) {
             $commandArguments = sprintf('%s %s', $this->projectName, ('latest' !== $this->version) ? $this->version : '');

--- a/src/Symfony/Installer/SelfUpdateCommand.php
+++ b/src/Symfony/Installer/SelfUpdateCommand.php
@@ -136,6 +136,8 @@ class SelfUpdateCommand extends DownloadCommand
             if ($this->output->isVeryVerbose()) {
                 $this->output->writeln($e->getMessage());
             }
+
+            return 1;
         }
     }
 
@@ -148,11 +150,11 @@ class SelfUpdateCommand extends DownloadCommand
     {
         // check for permissions in local filesystem before start downloading files
         if (!is_writable($this->currentInstallerFile)) {
-            throw new \RuntimeException('Symfony Installer update failed: the "'.$this->currentInstallerFile.'" file could not be written');
+            throw new IOException('Symfony Installer update failed: the "'.$this->currentInstallerFile.'" file could not be written');
         }
 
         if (!is_writable($this->tempDir)) {
-            throw new \RuntimeException('Symfony Installer update failed: the "'.$this->tempDir.'" directory used to download files temporarily could not be written');
+            throw new IOException('Symfony Installer update failed: the "'.$this->tempDir.'" directory used to download files temporarily could not be written');
         }
 
         if (false === $newInstaller = $this->getUrlContents($this->remoteInstallerFile)) {
@@ -225,7 +227,7 @@ class SelfUpdateCommand extends DownloadCommand
     {
         $this->output->writeln(array(
             '',
-            'There was an error while updating the installer.',
+            '<error>There was an error while updating the installer.</error>',
             'The previous Symfony Installer version has been restored.',
             '',
         ));


### PR DESCRIPTION
Currently, the `self-update` command does not return an alerting enough exit message or status code on permission errors.
I saw in the code that it was intended, but it did not work well enough.

This PR fixes this issue by modifying the thrown exception type in certain cases, and by making the fallback exception to return error code 1, and by coloring the rollback message.

Before:
![image](https://cloud.githubusercontent.com/assets/534550/18207370/447a9004-712b-11e6-99f9-78bc05529dc9.png)

After:
![image](https://cloud.githubusercontent.com/assets/534550/18207382/5530b4be-712b-11e6-9763-e18fe4fdf6cf.png)
