### PR TITLE
Extracted the code related to Composer into a new ComposerManager class

### DIFF
--- a/src/Symfony/Installer/DemoCommand.php
+++ b/src/Symfony/Installer/DemoCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Installer\Exception\AbortException;
+use Symfony\Installer\Manager\ComposerManager;
 
 /**
  * This command creates a full-featured Symfony demo application.
@@ -60,6 +61,8 @@ class DemoCommand extends DownloadCommand
             $this->projectDir = $this->fs->isAbsolutePath($directory) ? $directory : getcwd().DIRECTORY_SEPARATOR.$directory;
             $this->projectName = basename($directory);
         }
+
+        $this->composerManager = new ComposerManager($this->projectDir);
     }
 
     /**
@@ -75,7 +78,7 @@ class DemoCommand extends DownloadCommand
                 ->download()
                 ->extract()
                 ->cleanUp()
-                ->updateComposerJson()
+                ->updateComposerConfig()
                 ->createGitIgnore()
                 ->checkSymfonyRequirements()
                 ->displayInstallationResult()

--- a/src/Symfony/Installer/DownloadCommand.php
+++ b/src/Symfony/Installer/DownloadCommand.php
@@ -28,6 +28,7 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Intl\Exception\MethodArgumentValueNotImplementedException;
 use Symfony\Installer\Exception\AbortException;
+use Symfony\Installer\Manager\ComposerManager;
 
 /**
  * Abstract command used by commands which download and extract compressed Symfony files.
@@ -81,6 +82,9 @@ abstract class DownloadCommand extends Command
      * @var array The requirement errors
      */
     protected $requirementsErrors = array();
+
+    /** @var ComposerManager */
+    protected $composerManager;
 
     /**
      * Returns the type of the downloaded application in a human readable format.
@@ -363,23 +367,9 @@ abstract class DownloadCommand extends Command
      *
      * @return $this
      */
-    protected function updateComposerJson()
+    protected function updateComposerConfig()
     {
-        $composerConfig = $this->getProjectComposerConfig();
-
-        if (isset($composerConfig['config']['platform']['php'])) {
-            unset($composerConfig['config']['platform']['php']);
-
-            if (empty($composerConfig['config']['platform'])) {
-                unset($composerConfig['config']['platform']);
-            }
-
-            if (empty($composerConfig['config'])) {
-                unset($composerConfig['config']);
-            }
-        }
-
-        $this->saveProjectComposerConfig($composerConfig);
+        $this->composerManager->initializeProjectConfig();
 
         return $this;
     }
@@ -418,17 +408,13 @@ abstract class DownloadCommand extends Command
      */
     protected function getInstalledSymfonyVersion()
     {
-        $composer = json_decode(file_get_contents($this->projectDir.'/composer.lock'), true);
+        $symfonyVersion = $this->composerManager->getPackageVersion('symfony/symfony');
 
-        foreach ($composer['packages'] as $package) {
-            if ('symfony/symfony' === $package['name']) {
-                if ('v' === substr($package['version'], 0, 1)) {
-                    return substr($package['version'], 1);
-                };
+        if (!empty($symfonyVersion) && 'v' === substr($symfonyVersion, 0, 1)) {
+            return substr($symfonyVersion, 1);
+        };
 
-                return $package['version'];
-            }
-        }
+        return $symfonyVersion;
     }
 
     /**
@@ -598,107 +584,6 @@ abstract class DownloadCommand extends Command
         $client = $this->getGuzzleClient();
 
         return $client->get($url)->getBody()->getContents();
-    }
-
-    /**
-     * It returns the project's Composer config as a PHP array.
-     *
-     * @return $this|array
-     */
-    protected function getProjectComposerConfig()
-    {
-        $composerJsonFilepath = $this->projectDir.'/composer.json';
-
-        if (!is_writable($composerJsonFilepath)) {
-            if ($this->output->isVerbose()) {
-                $this->output->writeln(sprintf(
-                    " <comment>[WARNING]</comment> Project's Composer config cannot be updated because\n".
-                    " the <comment>%s</comment> file is not writable.\n",
-                    $composerJsonFilepath
-                ));
-            }
-
-            return $this;
-        }
-
-        return json_decode(file_get_contents($composerJsonFilepath), true);
-    }
-
-    /**
-     * It saves the given PHP array as the project's Composer config. In addition
-     * to JSON-serializing the contents, it synchronizes the composer.lock file to
-     * avoid out-of-sync Composer errors.
-     *
-     * @param array $config
-     */
-    protected function saveProjectComposerConfig(array $config)
-    {
-        $composerJsonFilepath = $this->projectDir.'/composer.json';
-        $this->fs->dumpFile($composerJsonFilepath, json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");
-
-        $this->syncComposerLockFile();
-    }
-
-    /**
-     * Updates the hash values stored in composer.lock to avoid out-of-sync
-     * problems when the composer.json file contents are changed.
-     */
-    private function syncComposerLockFile()
-    {
-        $composerJsonFileContents = file_get_contents($this->projectDir.'/composer.json');
-        $composerLockFileContents = json_decode(file_get_contents($this->projectDir.'/composer.lock'), true);
-
-        if (array_key_exists('hash', $composerLockFileContents)) {
-            $composerLockFileContents['hash'] = md5($composerJsonFileContents);
-        }
-
-        if (array_key_exists('content-hash', $composerLockFileContents)) {
-            $composerLockFileContents['content-hash'] = $this->getComposerContentHash($composerJsonFileContents);
-        }
-
-        $this->fs->dumpFile($this->projectDir.'/composer.lock', json_encode($composerLockFileContents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");
-    }
-
-    /**
-     * Returns the md5 hash of the sorted content of the composer file.
-     *
-     * @see https://github.com/composer/composer/blob/master/src/Composer/Package/Locker.php (getContentHash() method)
-     *
-     * @param string $composerJsonFileContents The contents of the composer.json file.
-     *
-     * @return string The hash of the composer file content.
-     */
-    private function getComposerContentHash($composerJsonFileContents)
-    {
-        $composerConfig = json_decode($composerJsonFileContents, true);
-
-        $relevantKeys = array(
-            'name',
-            'version',
-            'require',
-            'require-dev',
-            'conflict',
-            'replace',
-            'provide',
-            'minimum-stability',
-            'prefer-stable',
-            'repositories',
-            'extra',
-        );
-
-        $relevantComposerConfig = array();
-
-        foreach (array_intersect($relevantKeys, array_keys($composerConfig)) as $key) {
-            $relevantComposerConfig[$key] = $composerConfig[$key];
-        }
-
-        if (isset($composerConfig['config']['platform'])) {
-            $relevantComposerConfig['config']['platform'] = $composerConfig['config']['platform'];
-        }
-
-        ksort($relevantComposerConfig);
-
-        return md5(json_encode($relevantComposerConfig));
     }
 
     /**

--- a/src/Symfony/Installer/Manager/ComposerManager.php
+++ b/src/Symfony/Installer/Manager/ComposerManager.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Symfony\Installer\Manager;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+class ComposerManager
+{
+    private $projectDir;
+    private $fs;
+
+    public function __construct($projectDir)
+    {
+        $this->projectDir = $projectDir;
+        $this->fs = new Filesystem();
+    }
+
+    public function initializeProjectConfig()
+    {
+        $composerConfig = $this->getProjectConfig();
+
+        if (isset($composerConfig['config']['platform']['php'])) {
+            unset($composerConfig['config']['platform']['php']);
+
+            if (empty($composerConfig['config']['platform'])) {
+                unset($composerConfig['config']['platform']);
+            }
+
+            if (empty($composerConfig['config'])) {
+                unset($composerConfig['config']);
+            }
+        }
+
+        $this->saveProjectConfig($composerConfig);
+    }
+
+    public function updateProjectConfig(array $newConfig)
+    {
+        $oldConfig = $this->getProjectConfig();
+        $projectConfig = array_replace_recursive($oldConfig, $newConfig);
+
+        // remove null values from project's config
+        $projectConfig = array_filter($projectConfig, function($value) { return !is_null($value); });
+
+        $this->saveProjectConfig($projectConfig);
+    }
+
+    public function getPackageVersion($packageName)
+    {
+        $composerLockFileContents = json_decode(file_get_contents($this->projectDir.'/composer.lock'), true);
+
+        foreach ($composerLockFileContents['packages'] as $packageConfig) {
+            if ($packageName === $packageConfig['name']) {
+                return $packageConfig['version'];
+            }
+        }
+    }
+
+    /**
+     * Generates a good Composer project name based on the application name
+     * and on the user name.
+     *
+     * @param $projectName
+     *
+     * @return string The generated Composer package name
+     */
+    public function createPackageName($projectName)
+    {
+        if (!empty($_SERVER['USERNAME'])) {
+            $packageName = $_SERVER['USERNAME'].'/'.$projectName;
+        } elseif (true === extension_loaded('posix') && $user = posix_getpwuid(posix_getuid())) {
+            $packageName = $user['name'].'/'.$projectName;
+        } elseif (get_current_user()) {
+            $packageName = get_current_user().'/'.$projectName;
+        } else {
+            // package names must be in the format foo/bar
+            $packageName = $projectName.'/'.$projectName;
+        }
+
+        return $this->fixPackageName($packageName);
+    }
+
+    /**
+     * It returns the project's Composer config as a PHP array.
+     *
+     * @return array
+     */
+    private function getProjectConfig()
+    {
+        $composerJsonPath = $this->projectDir.'/composer.json';
+        if (!is_writable($composerJsonPath)) {
+            return [];
+        }
+
+        return json_decode(file_get_contents($composerJsonPath), true);
+    }
+
+    /**
+     * It saves the given PHP array as the project's Composer config. In addition
+     * to JSON-serializing the contents, it synchronizes the composer.lock file to
+     * avoid out-of-sync Composer errors.
+     *
+     * @param array $config
+     */
+    private function saveProjectConfig(array $config)
+    {
+        $composerJsonPath = $this->projectDir.'/composer.json';
+        $this->fs->dumpFile($composerJsonPath, json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");
+
+        $this->syncComposerLockFile();
+    }
+
+    /**
+     * Updates the hash values stored in composer.lock to avoid out-of-sync
+     * problems when the composer.json file contents are changed.
+     */
+    private function syncComposerLockFile()
+    {
+        $composerJsonFileContents = file_get_contents($this->projectDir.'/composer.json');
+        $composerLockFileContents = json_decode(file_get_contents($this->projectDir.'/composer.lock'), true);
+
+        if (array_key_exists('hash', $composerLockFileContents)) {
+            $composerLockFileContents['hash'] = md5($composerJsonFileContents);
+        }
+
+        if (array_key_exists('content-hash', $composerLockFileContents)) {
+            $composerLockFileContents['content-hash'] = $this->getComposerContentHash($composerJsonFileContents);
+        }
+
+        $this->fs->dumpFile($this->projectDir.'/composer.lock', json_encode($composerLockFileContents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");
+    }
+
+    /**
+     * Returns the md5 hash of the sorted content of the composer file.
+     *
+     * @see https://github.com/composer/composer/blob/master/src/Composer/Package/Locker.php (getContentHash() method)
+     *
+     * @param string $composerJsonFileContents The contents of the composer.json file.
+     *
+     * @return string The hash of the composer file content.
+     */
+    private function getComposerContentHash($composerJsonFileContents)
+    {
+        $composerConfig = json_decode($composerJsonFileContents, true);
+
+        $relevantKeys = array(
+            'name',
+            'version',
+            'require',
+            'require-dev',
+            'conflict',
+            'replace',
+            'provide',
+            'minimum-stability',
+            'prefer-stable',
+            'repositories',
+            'extra',
+        );
+
+        $relevantComposerConfig = array();
+
+        foreach (array_intersect($relevantKeys, array_keys($composerConfig)) as $key) {
+            $relevantComposerConfig[$key] = $composerConfig[$key];
+        }
+
+        if (isset($composerConfig['config']['platform'])) {
+            $relevantComposerConfig['config']['platform'] = $composerConfig['config']['platform'];
+        }
+
+        ksort($relevantComposerConfig);
+
+        return md5(json_encode($relevantComposerConfig));
+    }
+
+    /**
+     * Transforms a project name into a valid Composer package name.
+     *
+     * @param string $name The project name to transform
+     *
+     * @return string The valid Composer package name
+     */
+    private function fixPackageName($name)
+    {
+        $name = str_replace(
+            ['à', 'á', 'â', 'ä', 'æ', 'ã', 'å', 'ā', 'é', 'è', 'ê', 'ë', 'ę', 'ė', 'ē', 'ī', 'į', 'í', 'ì', 'ï', 'î', 'ō', 'ø', 'œ', 'õ', 'ó', 'ò', 'ö', 'ô', 'ū', 'ú', 'ù', 'ü', 'û', 'ç', 'ć', 'č', 'ł', 'ñ', 'ń', 'ß', 'ś', 'š', 'ŵ', 'ŷ', 'ÿ', 'ź', 'ž', 'ż'],
+            ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'e', 'e', 'e', 'e', 'e', 'e', 'e', 'i', 'i', 'i', 'i', 'i', 'i', 'o', 'o', 'o', 'o', 'o', 'o', 'o', 'o', 'u', 'u', 'u', 'u', 'u', 'c', 'c', 'c', 'l', 'n', 'n', 's', 's', 's', 'w', 'y', 'y', 'z', 'z', 'z'],
+            $name
+        );
+        $name = preg_replace('#[^A-Za-z0-9_./-]+#', '', $name);
+
+        return strtolower($name);
+    }
+}

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -1,356 +1,193 @@
 <?php
 
-/*
- * This file is part of the Symfony Installer package.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
+namespace Symfony\Installer\Manager;
 
-namespace Symfony\Installer;
+use Symfony\Component\Filesystem\Filesystem;
 
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Installer\Exception\AbortException;
-use Symfony\Installer\Manager\ComposerManager;
-
-/**
- * This command creates new Symfony projects for the given Symfony version.
- *
- * @author Christophe Coevoet <stof@notk.org>
- * @author Javier Eguiluz <javier.eguiluz@gmail.com>
- */
-class NewCommand extends DownloadCommand
+class ComposerManager
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function configure()
+    private $projectDir;
+    private $fs;
+
+    public function __construct($projectDir)
     {
-        $this
-            ->setName('new')
-            ->setDescription('Creates a new Symfony project.')
-            ->addArgument('directory', InputArgument::REQUIRED, 'Directory where the new project will be created.')
-            ->addArgument('version', InputArgument::OPTIONAL, 'The Symfony version to be installed (defaults to the latest stable version).', 'latest')
-        ;
+        $this->projectDir = $projectDir;
+        $this->fs = new Filesystem();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    public function initializeProjectConfig()
     {
-        parent::initialize($input, $output);
+        $composerConfig = $this->getProjectConfig();
 
-        $directory = rtrim(trim($input->getArgument('directory')), DIRECTORY_SEPARATOR);
-        $this->version = trim($input->getArgument('version'));
-        $this->projectDir = $this->fs->isAbsolutePath($directory) ? $directory : getcwd().DIRECTORY_SEPARATOR.$directory;
-        $this->projectName = basename($directory);
+        if (isset($composerConfig['config']['platform']['php'])) {
+            unset($composerConfig['config']['platform']['php']);
 
-        $this->composerManager = new ComposerManager($this->projectDir);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
-    {
-        try {
-            $this
-                ->checkInstallerVersion()
-                ->checkProjectName()
-                ->checkSymfonyVersionIsInstallable()
-                ->checkPermissions()
-                ->download()
-                ->extract()
-                ->cleanUp()
-                ->dumpReadmeFile()
-                ->updateParameters()
-                ->updateComposerConfig()
-                ->createGitIgnore()
-                ->checkSymfonyRequirements()
-                ->displayInstallationResult()
-            ;
-        } catch (AbortException $e) {
-            aborted:
-
-            $output->writeln('');
-            $output->writeln('<error>Aborting download and cleaning up temporary directories.</>');
-
-            $this->cleanUp();
-
-            return 1;
-        } catch (\Exception $e) {
-            // Guzzle can wrap the AbortException in a GuzzleException
-            if ($e->getPrevious() instanceof AbortException) {
-                goto aborted;
+            if (empty($composerConfig['config']['platform'])) {
+                unset($composerConfig['config']['platform']);
             }
 
-            $this->cleanUp();
-            throw $e;
-        }
-    }
-
-    /**
-     * Checks whether the given Symfony version is installable by the installer.
-     * Due to the changes introduced in the Icu/Intl components
-     * (see http://symfony.com/blog/new-in-symfony-2-6-farewell-to-icu-component)
-     * not all the previous Symfony versions are installable by the installer.
-     *
-     * The rules to decide if the version is installable are as follows:
-     *
-     *   - 2.0, 2.1, 2.2 and 2.4 cannot be installed because they are unmaintained.
-     *   - 2.3 can be installed starting from version 2.3.21 (inclusive)
-     *   - 2.5 can be installed starting from version 2.5.6 (inclusive)
-     *   - 2.6, 2.7, 2.8 and 2.9 can be installed regardless the version.
-     *
-     * @return $this
-     *
-     * @throws \RuntimeException If the given Symfony version is not compatible with this installer
-     */
-    protected function checkSymfonyVersionIsInstallable()
-    {
-        // validate the given version syntax
-        if (!preg_match('/^latest|lts|[2-9]\.\d(?:\.\d{1,2})?(?:-(?:dev|BETA\d*|RC\d*))?$/i', $this->version)) {
-            throw new \RuntimeException(sprintf(
-                "The Symfony version can be a branch number (e.g. 2.8), a full version\n".
-                "number (e.g. 3.1.4), a special word ('latest' or 'lts') and a unstable\n".
-                "version number (e.g. 3.2.0-rc1) but '%s' was given.", $this->version
-            ));
-        }
-
-        // Get the full list of Symfony versions to check if it's installable
-        $client = $this->getGuzzleClient();
-        $symfonyVersions = $client->get('http://symfony.com/versions.json')->json();
-        if (empty($symfonyVersions)) {
-            throw new \RuntimeException(
-                "There was a problem while downloading the list of Symfony versions from\n".
-                "symfony.com. Check that you are online and the following URL is accessible:\n\n".
-                'http://symfony.com/versions.json'
-            );
-        }
-
-        // if a branch number is used, transform it into a real version number
-        if (preg_match('/^[2-9]\.\d$/', $this->version)) {
-            if (!isset($symfonyVersions[$this->version])) {
-                throw new \RuntimeException(sprintf(
-                    "The selected branch (%s) does not exist, or is not maintained.\n".
-                    "To solve this issue, install Symfony with the latest stable release:\n\n".
-                    '%s %s %s',  $this->version, $_SERVER['PHP_SELF'], $this->getName(), $this->projectDir
-                ));
+            if (empty($composerConfig['config'])) {
+                unset($composerConfig['config']);
             }
-
-            $this->version = $symfonyVersions[$this->version];
         }
 
-        // if a special version name is used, transform it into a real version number
-        if (in_array($this->version, array('latest', 'lts'))) {
-            $this->version = $symfonyVersions[$this->version];
+        $this->saveProjectConfig($composerConfig);
+    }
+
+    public function updateProjectConfig(array $newConfig)
+    {
+        $oldConfig = $this->getProjectConfig();
+        $projectConfig = array_replace_recursive($oldConfig, $newConfig);
+
+        // remove null values from project's config
+        $projectConfig = array_filter($projectConfig, function($value) { return !is_null($value); });
+
+        $this->saveProjectConfig($projectConfig);
+    }
+
+    public function getPackageVersion($packageName)
+    {
+        $composerLockFileContents = json_decode(file_get_contents($this->projectDir.'/composer.lock'), true);
+
+        foreach ($composerLockFileContents['packages'] as $packageConfig) {
+            if ($packageName === $packageConfig['name']) {
+                return $packageConfig['version'];
+            }
         }
-
-        // versions are case-sensitive in the download server (3.1.0-rc1 must be 3.1.0-RC1)
-        if ($isUnstableVersion = preg_match('/^.*\-(BETA|RC)\d*$/i', $this->version)) {
-            $this->version = strtoupper($this->version);
-        }
-
-        $isNonInstallable = in_array($this->version, $symfonyVersions['non_installable']);
-        $isInstallable = in_array($this->version, $symfonyVersions['installable']);
-
-        // installable and non-installable versions are explicitly declared in the
-        // list of versions; there is an edge-case: unstable versions are not listed
-        // and they are generally installable (e.g. 3.1.0-RC1)
-        if ($isNonInstallable || (!$isInstallable && !$isUnstableVersion)) {
-            throw new \RuntimeException(sprintf(
-                "The selected version (%s) cannot be installed because it is not compatible\n".
-                "with this installer or because it hasn't been published as a package yet.\n".
-                "To solve this issue install Symfony manually executing the following command:\n\n".
-                'composer create-project symfony/framework-standard-edition %s %s',
-                $this->version, $this->projectDir, $this->version
-            ));
-        }
-
-        // check that the system has the PHP version required by the Symfony version to be installed
-        if (version_compare($this->version, '3.0.0', '>=') && version_compare(phpversion(), '5.5.9', '<')) {
-            throw new \RuntimeException(sprintf(
-                "The selected version (%s) cannot be installed because it requires\n".
-                "PHP 5.5.9 or higher and your system has PHP %s installed.\n",
-                $this->version, phpversion()
-            ));
-        }
-
-        if ($isUnstableVersion) {
-            $this->output->writeln("\n <bg=red> WARNING </> You are downloading an unstable Symfony version.");
-        }
-
-        return $this;
     }
 
     /**
-     * Removes all the temporary files and directories created to
-     * download the project and removes Symfony-related files that don't make
-     * sense in a proprietary project.
+     * Generates a good Composer project name based on the application name
+     * and on the user name.
      *
-     * @return $this
-     */
-    protected function cleanUp()
-    {
-        $this->fs->remove(dirname($this->downloadedFilePath));
-
-        try {
-            $licenseFile = array($this->projectDir.'/LICENSE');
-            $upgradeFiles = glob($this->projectDir.'/UPGRADE*.md');
-            $changelogFiles = glob($this->projectDir.'/CHANGELOG*.md');
-
-            $filesToRemove = array_merge($licenseFile, $upgradeFiles, $changelogFiles);
-            $this->fs->remove($filesToRemove);
-        } catch (\Exception $e) {
-            // don't throw an exception in case any of the Symfony-related files cannot
-            // be removed, because this is just an enhancement, not something mandatory
-            // for the project
-        }
-
-        return $this;
-    }
-
-    /**
-     * It displays the message with the result of installing Symfony
-     * and provides some pointers to the user.
+     * @param $projectName
      *
-     * @return $this
+     * @return string The generated Composer package name
      */
-    protected function displayInstallationResult()
+    public function createPackageName($projectName)
     {
-        if (empty($this->requirementsErrors)) {
-            $this->output->writeln(sprintf(
-                " <info>%s</info>  Symfony %s was <info>successfully installed</info>. Now you can:\n",
-                defined('PHP_WINDOWS_VERSION_BUILD') ? 'OK' : '✔',
-                $this->getInstalledSymfonyVersion()
-            ));
+        if (!empty($_SERVER['USERNAME'])) {
+            $packageName = $_SERVER['USERNAME'].'/'.$projectName;
+        } elseif (true === extension_loaded('posix') && $user = posix_getpwuid(posix_getuid())) {
+            $packageName = $user['name'].'/'.$projectName;
+        } elseif (get_current_user()) {
+            $packageName = get_current_user().'/'.$projectName;
         } else {
-            $this->output->writeln(sprintf(
-                " <comment>%s</comment>  Symfony %s was <info>successfully installed</info> but your system doesn't meet its\n".
-                "     technical requirements! Fix the following issues before executing\n".
-                "     your Symfony application:\n",
-                defined('PHP_WINDOWS_VERSION_BUILD') ? 'FAILED' : '✕',
-                $this->getInstalledSymfonyVersion()
-            ));
-
-            foreach ($this->requirementsErrors as $helpText) {
-                $this->output->writeln(' * '.$helpText);
-            }
-
-            $checkFile = $this->isSymfony3() ? 'bin/symfony_requirements' : 'app/check.php';
-
-            $this->output->writeln(sprintf(
-                " After fixing these issues, re-check Symfony requirements executing this command:\n\n".
-                "   <comment>php %s/%s</comment>\n\n".
-                " Then, you can:\n",
-                $this->projectName, $checkFile
-            ));
+            // package names must be in the format foo/bar
+            $packageName = $projectName.'/'.$projectName;
         }
 
-        if ('.' !== $this->projectDir) {
-            $this->output->writeln(sprintf(
-                "    * Change your current directory to <comment>%s</comment>\n", $this->projectDir
-            ));
-        }
-
-        $consoleDir = ($this->isSymfony3() ? 'bin' : 'app');
-
-        $this->output->writeln(sprintf(
-            "    * Configure your application in <comment>app/config/parameters.yml</comment> file.\n\n".
-            "    * Run your application:\n".
-            "        1. Execute the <comment>php %s/console server:run</comment> command.\n".
-            "        2. Browse to the <comment>http://localhost:8000</comment> URL.\n\n".
-            "    * Read the documentation at <comment>http://symfony.com/doc</comment>\n",
-            $consoleDir
-        ));
-
-        return $this;
+        return $this->fixPackageName($packageName);
     }
 
     /**
-     * Dump a basic README.md file.
+     * It returns the project's Composer config as a PHP array.
      *
-     * @return $this
+     * @return array
      */
-    protected function dumpReadmeFile()
+    private function getProjectConfig()
     {
-        $readmeContents = sprintf("%s\n%s\n\nA Symfony project created on %s.\n", $this->projectName, str_repeat('=', strlen($this->projectName)), date('F j, Y, g:i a'));
-        try {
-            $this->fs->dumpFile($this->projectDir.'/README.md', $readmeContents);
-        } catch (\Exception $e) {
-            // don't throw an exception in case the file could not be created,
-            // because this is just an enhancement, not something mandatory
-            // for the project
+        $composerJsonPath = $this->projectDir.'/composer.json';
+        if (!is_writable($composerJsonPath)) {
+            return [];
         }
 
-        return $this;
+        return json_decode(file_get_contents($composerJsonPath), true);
     }
 
     /**
-     * Updates the Symfony parameters.yml file to replace default configuration
-     * values with better generated values.
+     * It saves the given PHP array as the project's Composer config. In addition
+     * to JSON-serializing the contents, it synchronizes the composer.lock file to
+     * avoid out-of-sync Composer errors.
      *
-     * @return $this
+     * @param array $config
      */
-    protected function updateParameters()
+    private function saveProjectConfig(array $config)
     {
-        $filename = $this->projectDir.'/app/config/parameters.yml';
+        $composerJsonPath = $this->projectDir.'/composer.json';
+        $this->fs->dumpFile($composerJsonPath, json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");
 
-        if (!is_writable($filename)) {
-            if ($this->output->isVerbose()) {
-                $this->output->writeln(sprintf(
-                    " <comment>[WARNING]</comment> The value of the <info>secret</info> configuration option cannot be updated because\n".
-                    " the <comment>%s</comment> file is not writable.\n",
-                    $filename
-                ));
-            }
+        $this->syncComposerLockFile();
+    }
 
-            return $this;
+    /**
+     * Updates the hash values stored in composer.lock to avoid out-of-sync
+     * problems when the composer.json file contents are changed.
+     */
+    private function syncComposerLockFile()
+    {
+        $composerJsonFileContents = file_get_contents($this->projectDir.'/composer.json');
+        $composerLockFileContents = json_decode(file_get_contents($this->projectDir.'/composer.lock'), true);
+
+        if (array_key_exists('hash', $composerLockFileContents)) {
+            $composerLockFileContents['hash'] = md5($composerJsonFileContents);
         }
 
-        $ret = str_replace('ThisTokenIsNotSoSecretChangeIt', $this->generateRandomSecret(), file_get_contents($filename));
-        file_put_contents($filename, $ret);
+        if (array_key_exists('content-hash', $composerLockFileContents)) {
+            $composerLockFileContents['content-hash'] = $this->getComposerContentHash($composerJsonFileContents);
+        }
 
-        return $this;
+        $this->fs->dumpFile($this->projectDir.'/composer.lock', json_encode($composerLockFileContents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");
     }
 
     /**
-     * Updates the composer.json file to provide better values for some of the
-     * default configuration values.
+     * Returns the md5 hash of the sorted content of the composer file.
      *
-     * @return $this
+     * @see https://github.com/composer/composer/blob/master/src/Composer/Package/Locker.php (getContentHash() method)
+     *
+     * @param string $composerJsonFileContents The contents of the composer.json file.
+     *
+     * @return string The hash of the composer file content.
      */
-    protected function updateComposerConfig()
+    private function getComposerContentHash($composerJsonFileContents)
     {
-        parent::updateComposerConfig();
-        $this->composerManager->updateProjectConfig([
-            'name' => $this->composerManager->createPackageName($this->projectName),
-            'license' => 'proprietary',
-            'description' => null,
-            'extra' => ['branch-alias' => null],
-        ]);
+        $composerConfig = json_decode($composerJsonFileContents, true);
 
-        return $this;
+        $relevantKeys = array(
+            'name',
+            'version',
+            'require',
+            'require-dev',
+            'conflict',
+            'replace',
+            'provide',
+            'minimum-stability',
+            'prefer-stable',
+            'repositories',
+            'extra',
+        );
+
+        $relevantComposerConfig = array();
+
+        foreach (array_intersect($relevantKeys, array_keys($composerConfig)) as $key) {
+            $relevantComposerConfig[$key] = $composerConfig[$key];
+        }
+
+        if (isset($composerConfig['config']['platform'])) {
+            $relevantComposerConfig['config']['platform'] = $composerConfig['config']['platform'];
+        }
+
+        ksort($relevantComposerConfig);
+
+        return md5(json_encode($relevantComposerConfig));
     }
 
     /**
-     * {@inheritdoc}
+     * Transforms a project name into a valid Composer package name.
+     *
+     * @param string $name The project name to transform
+     *
+     * @return string The valid Composer package name
      */
-    protected function getDownloadedApplicationType()
+    private function fixPackageName($name)
     {
-        return 'Symfony';
-    }
+        $name = str_replace(
+            ['à', 'á', 'â', 'ä', 'æ', 'ã', 'å', 'ā', 'é', 'è', 'ê', 'ë', 'ę', 'ė', 'ē', 'ī', 'į', 'í', 'ì', 'ï', 'î', 'ō', 'ø', 'œ', 'õ', 'ó', 'ò', 'ö', 'ô', 'ū', 'ú', 'ù', 'ü', 'û', 'ç', 'ć', 'č', 'ł', 'ñ', 'ń', 'ß', 'ś', 'š', 'ŵ', 'ŷ', 'ÿ', 'ź', 'ž', 'ż'],
+            ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'e', 'e', 'e', 'e', 'e', 'e', 'e', 'i', 'i', 'i', 'i', 'i', 'i', 'o', 'o', 'o', 'o', 'o', 'o', 'o', 'o', 'u', 'u', 'u', 'u', 'u', 'c', 'c', 'c', 'l', 'n', 'n', 's', 's', 's', 'w', 'y', 'y', 'z', 'z', 'z'],
+            $name
+        );
+        $name = preg_replace('#[^A-Za-z0-9_./-]+#', '', $name);
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getRemoteFileUrl()
-    {
-        return 'http://symfony.com/download?v=Symfony_Standard_Vendors_'.$this->version;
+        return strtolower($name);
     }
 }

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -1,193 +1,356 @@
 <?php
 
-namespace Symfony\Installer\Manager;
+/*
+ * This file is part of the Symfony Installer package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
-use Symfony\Component\Filesystem\Filesystem;
+namespace Symfony\Installer;
 
-class ComposerManager
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Installer\Exception\AbortException;
+use Symfony\Installer\Manager\ComposerManager;
+
+/**
+ * This command creates new Symfony projects for the given Symfony version.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+class NewCommand extends DownloadCommand
 {
-    private $projectDir;
-    private $fs;
-
-    public function __construct($projectDir)
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
     {
-        $this->projectDir = $projectDir;
-        $this->fs = new Filesystem();
+        $this
+            ->setName('new')
+            ->setDescription('Creates a new Symfony project.')
+            ->addArgument('directory', InputArgument::REQUIRED, 'Directory where the new project will be created.')
+            ->addArgument('version', InputArgument::OPTIONAL, 'The Symfony version to be installed (defaults to the latest stable version).', 'latest')
+        ;
     }
 
-    public function initializeProjectConfig()
+    /**
+     * {@inheritdoc}
+     */
+    protected function initialize(InputInterface $input, OutputInterface $output)
     {
-        $composerConfig = $this->getProjectConfig();
+        parent::initialize($input, $output);
 
-        if (isset($composerConfig['config']['platform']['php'])) {
-            unset($composerConfig['config']['platform']['php']);
+        $directory = rtrim(trim($input->getArgument('directory')), DIRECTORY_SEPARATOR);
+        $this->version = trim($input->getArgument('version'));
+        $this->projectDir = $this->fs->isAbsolutePath($directory) ? $directory : getcwd().DIRECTORY_SEPARATOR.$directory;
+        $this->projectName = basename($directory);
 
-            if (empty($composerConfig['config']['platform'])) {
-                unset($composerConfig['config']['platform']);
-            }
-
-            if (empty($composerConfig['config'])) {
-                unset($composerConfig['config']);
-            }
-        }
-
-        $this->saveProjectConfig($composerConfig);
+        $this->composerManager = new ComposerManager($this->projectDir);
     }
 
-    public function updateProjectConfig(array $newConfig)
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $oldConfig = $this->getProjectConfig();
-        $projectConfig = array_replace_recursive($oldConfig, $newConfig);
+        try {
+            $this
+                ->checkInstallerVersion()
+                ->checkProjectName()
+                ->checkSymfonyVersionIsInstallable()
+                ->checkPermissions()
+                ->download()
+                ->extract()
+                ->cleanUp()
+                ->dumpReadmeFile()
+                ->updateParameters()
+                ->updateComposerConfig()
+                ->createGitIgnore()
+                ->checkSymfonyRequirements()
+                ->displayInstallationResult()
+            ;
+        } catch (AbortException $e) {
+            aborted:
 
-        // remove null values from project's config
-        $projectConfig = array_filter($projectConfig, function($value) { return !is_null($value); });
+            $output->writeln('');
+            $output->writeln('<error>Aborting download and cleaning up temporary directories.</>');
 
-        $this->saveProjectConfig($projectConfig);
-    }
+            $this->cleanUp();
 
-    public function getPackageVersion($packageName)
-    {
-        $composerLockFileContents = json_decode(file_get_contents($this->projectDir.'/composer.lock'), true);
-
-        foreach ($composerLockFileContents['packages'] as $packageConfig) {
-            if ($packageName === $packageConfig['name']) {
-                return $packageConfig['version'];
+            return 1;
+        } catch (\Exception $e) {
+            // Guzzle can wrap the AbortException in a GuzzleException
+            if ($e->getPrevious() instanceof AbortException) {
+                goto aborted;
             }
+
+            $this->cleanUp();
+            throw $e;
         }
     }
 
     /**
-     * Generates a good Composer project name based on the application name
-     * and on the user name.
+     * Checks whether the given Symfony version is installable by the installer.
+     * Due to the changes introduced in the Icu/Intl components
+     * (see http://symfony.com/blog/new-in-symfony-2-6-farewell-to-icu-component)
+     * not all the previous Symfony versions are installable by the installer.
      *
-     * @param $projectName
+     * The rules to decide if the version is installable are as follows:
      *
-     * @return string The generated Composer package name
+     *   - 2.0, 2.1, 2.2 and 2.4 cannot be installed because they are unmaintained.
+     *   - 2.3 can be installed starting from version 2.3.21 (inclusive)
+     *   - 2.5 can be installed starting from version 2.5.6 (inclusive)
+     *   - 2.6, 2.7, 2.8 and 2.9 can be installed regardless the version.
+     *
+     * @return $this
+     *
+     * @throws \RuntimeException If the given Symfony version is not compatible with this installer
      */
-    public function createPackageName($projectName)
+    protected function checkSymfonyVersionIsInstallable()
     {
-        if (!empty($_SERVER['USERNAME'])) {
-            $packageName = $_SERVER['USERNAME'].'/'.$projectName;
-        } elseif (true === extension_loaded('posix') && $user = posix_getpwuid(posix_getuid())) {
-            $packageName = $user['name'].'/'.$projectName;
-        } elseif (get_current_user()) {
-            $packageName = get_current_user().'/'.$projectName;
+        // validate the given version syntax
+        if (!preg_match('/^latest|lts|[2-9]\.\d(?:\.\d{1,2})?(?:-(?:dev|BETA\d*|RC\d*))?$/i', $this->version)) {
+            throw new \RuntimeException(sprintf(
+                "The Symfony version can be a branch number (e.g. 2.8), a full version\n".
+                "number (e.g. 3.1.4), a special word ('latest' or 'lts') and a unstable\n".
+                "version number (e.g. 3.2.0-rc1) but '%s' was given.", $this->version
+            ));
+        }
+
+        // Get the full list of Symfony versions to check if it's installable
+        $client = $this->getGuzzleClient();
+        $symfonyVersions = $client->get('http://symfony.com/versions.json')->json();
+        if (empty($symfonyVersions)) {
+            throw new \RuntimeException(
+                "There was a problem while downloading the list of Symfony versions from\n".
+                "symfony.com. Check that you are online and the following URL is accessible:\n\n".
+                'http://symfony.com/versions.json'
+            );
+        }
+
+        // if a branch number is used, transform it into a real version number
+        if (preg_match('/^[2-9]\.\d$/', $this->version)) {
+            if (!isset($symfonyVersions[$this->version])) {
+                throw new \RuntimeException(sprintf(
+                    "The selected branch (%s) does not exist, or is not maintained.\n".
+                    "To solve this issue, install Symfony with the latest stable release:\n\n".
+                    '%s %s %s',  $this->version, $_SERVER['PHP_SELF'], $this->getName(), $this->projectDir
+                ));
+            }
+
+            $this->version = $symfonyVersions[$this->version];
+        }
+
+        // if a special version name is used, transform it into a real version number
+        if (in_array($this->version, array('latest', 'lts'))) {
+            $this->version = $symfonyVersions[$this->version];
+        }
+
+        // versions are case-sensitive in the download server (3.1.0-rc1 must be 3.1.0-RC1)
+        if ($isUnstableVersion = preg_match('/^.*\-(BETA|RC)\d*$/i', $this->version)) {
+            $this->version = strtoupper($this->version);
+        }
+
+        $isNonInstallable = in_array($this->version, $symfonyVersions['non_installable']);
+        $isInstallable = in_array($this->version, $symfonyVersions['installable']);
+
+        // installable and non-installable versions are explicitly declared in the
+        // list of versions; there is an edge-case: unstable versions are not listed
+        // and they are generally installable (e.g. 3.1.0-RC1)
+        if ($isNonInstallable || (!$isInstallable && !$isUnstableVersion)) {
+            throw new \RuntimeException(sprintf(
+                "The selected version (%s) cannot be installed because it is not compatible\n".
+                "with this installer or because it hasn't been published as a package yet.\n".
+                "To solve this issue install Symfony manually executing the following command:\n\n".
+                'composer create-project symfony/framework-standard-edition %s %s',
+                $this->version, $this->projectDir, $this->version
+            ));
+        }
+
+        // check that the system has the PHP version required by the Symfony version to be installed
+        if (version_compare($this->version, '3.0.0', '>=') && version_compare(phpversion(), '5.5.9', '<')) {
+            throw new \RuntimeException(sprintf(
+                "The selected version (%s) cannot be installed because it requires\n".
+                "PHP 5.5.9 or higher and your system has PHP %s installed.\n",
+                $this->version, phpversion()
+            ));
+        }
+
+        if ($isUnstableVersion) {
+            $this->output->writeln("\n <bg=red> WARNING </> You are downloading an unstable Symfony version.");
+        }
+
+        return $this;
+    }
+
+    /**
+     * Removes all the temporary files and directories created to
+     * download the project and removes Symfony-related files that don't make
+     * sense in a proprietary project.
+     *
+     * @return $this
+     */
+    protected function cleanUp()
+    {
+        $this->fs->remove(dirname($this->downloadedFilePath));
+
+        try {
+            $licenseFile = array($this->projectDir.'/LICENSE');
+            $upgradeFiles = glob($this->projectDir.'/UPGRADE*.md');
+            $changelogFiles = glob($this->projectDir.'/CHANGELOG*.md');
+
+            $filesToRemove = array_merge($licenseFile, $upgradeFiles, $changelogFiles);
+            $this->fs->remove($filesToRemove);
+        } catch (\Exception $e) {
+            // don't throw an exception in case any of the Symfony-related files cannot
+            // be removed, because this is just an enhancement, not something mandatory
+            // for the project
+        }
+
+        return $this;
+    }
+
+    /**
+     * It displays the message with the result of installing Symfony
+     * and provides some pointers to the user.
+     *
+     * @return $this
+     */
+    protected function displayInstallationResult()
+    {
+        if (empty($this->requirementsErrors)) {
+            $this->output->writeln(sprintf(
+                " <info>%s</info>  Symfony %s was <info>successfully installed</info>. Now you can:\n",
+                defined('PHP_WINDOWS_VERSION_BUILD') ? 'OK' : '✔',
+                $this->getInstalledSymfonyVersion()
+            ));
         } else {
-            // package names must be in the format foo/bar
-            $packageName = $projectName.'/'.$projectName;
+            $this->output->writeln(sprintf(
+                " <comment>%s</comment>  Symfony %s was <info>successfully installed</info> but your system doesn't meet its\n".
+                "     technical requirements! Fix the following issues before executing\n".
+                "     your Symfony application:\n",
+                defined('PHP_WINDOWS_VERSION_BUILD') ? 'FAILED' : '✕',
+                $this->getInstalledSymfonyVersion()
+            ));
+
+            foreach ($this->requirementsErrors as $helpText) {
+                $this->output->writeln(' * '.$helpText);
+            }
+
+            $checkFile = $this->isSymfony3() ? 'bin/symfony_requirements' : 'app/check.php';
+
+            $this->output->writeln(sprintf(
+                " After fixing these issues, re-check Symfony requirements executing this command:\n\n".
+                "   <comment>php %s/%s</comment>\n\n".
+                " Then, you can:\n",
+                $this->projectName, $checkFile
+            ));
         }
 
-        return $this->fixPackageName($packageName);
+        if ('.' !== $this->projectDir) {
+            $this->output->writeln(sprintf(
+                "    * Change your current directory to <comment>%s</comment>\n", $this->projectDir
+            ));
+        }
+
+        $consoleDir = ($this->isSymfony3() ? 'bin' : 'app');
+
+        $this->output->writeln(sprintf(
+            "    * Configure your application in <comment>app/config/parameters.yml</comment> file.\n\n".
+            "    * Run your application:\n".
+            "        1. Execute the <comment>php %s/console server:run</comment> command.\n".
+            "        2. Browse to the <comment>http://localhost:8000</comment> URL.\n\n".
+            "    * Read the documentation at <comment>http://symfony.com/doc</comment>\n",
+            $consoleDir
+        ));
+
+        return $this;
     }
 
     /**
-     * It returns the project's Composer config as a PHP array.
+     * Dump a basic README.md file.
      *
-     * @return array
+     * @return $this
      */
-    private function getProjectConfig()
+    protected function dumpReadmeFile()
     {
-        $composerJsonPath = $this->projectDir.'/composer.json';
-        if (!is_writable($composerJsonPath)) {
-            return [];
+        $readmeContents = sprintf("%s\n%s\n\nA Symfony project created on %s.\n", $this->projectName, str_repeat('=', strlen($this->projectName)), date('F j, Y, g:i a'));
+        try {
+            $this->fs->dumpFile($this->projectDir.'/README.md', $readmeContents);
+        } catch (\Exception $e) {
+            // don't throw an exception in case the file could not be created,
+            // because this is just an enhancement, not something mandatory
+            // for the project
         }
 
-        return json_decode(file_get_contents($composerJsonPath), true);
+        return $this;
     }
 
     /**
-     * It saves the given PHP array as the project's Composer config. In addition
-     * to JSON-serializing the contents, it synchronizes the composer.lock file to
-     * avoid out-of-sync Composer errors.
+     * Updates the Symfony parameters.yml file to replace default configuration
+     * values with better generated values.
      *
-     * @param array $config
+     * @return $this
      */
-    private function saveProjectConfig(array $config)
+    protected function updateParameters()
     {
-        $composerJsonPath = $this->projectDir.'/composer.json';
-        $this->fs->dumpFile($composerJsonPath, json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");
+        $filename = $this->projectDir.'/app/config/parameters.yml';
 
-        $this->syncComposerLockFile();
+        if (!is_writable($filename)) {
+            if ($this->output->isVerbose()) {
+                $this->output->writeln(sprintf(
+                    " <comment>[WARNING]</comment> The value of the <info>secret</info> configuration option cannot be updated because\n".
+                    " the <comment>%s</comment> file is not writable.\n",
+                    $filename
+                ));
+            }
+
+            return $this;
+        }
+
+        $ret = str_replace('ThisTokenIsNotSoSecretChangeIt', $this->generateRandomSecret(), file_get_contents($filename));
+        file_put_contents($filename, $ret);
+
+        return $this;
     }
 
     /**
-     * Updates the hash values stored in composer.lock to avoid out-of-sync
-     * problems when the composer.json file contents are changed.
+     * Updates the composer.json file to provide better values for some of the
+     * default configuration values.
+     *
+     * @return $this
      */
-    private function syncComposerLockFile()
+    protected function updateComposerConfig()
     {
-        $composerJsonFileContents = file_get_contents($this->projectDir.'/composer.json');
-        $composerLockFileContents = json_decode(file_get_contents($this->projectDir.'/composer.lock'), true);
+        parent::updateComposerConfig();
+        $this->composerManager->updateProjectConfig([
+            'name' => $this->composerManager->createPackageName($this->projectName),
+            'license' => 'proprietary',
+            'description' => null,
+            'extra' => ['branch-alias' => null],
+        ]);
 
-        if (array_key_exists('hash', $composerLockFileContents)) {
-            $composerLockFileContents['hash'] = md5($composerJsonFileContents);
-        }
-
-        if (array_key_exists('content-hash', $composerLockFileContents)) {
-            $composerLockFileContents['content-hash'] = $this->getComposerContentHash($composerJsonFileContents);
-        }
-
-        $this->fs->dumpFile($this->projectDir.'/composer.lock', json_encode($composerLockFileContents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");
+        return $this;
     }
 
     /**
-     * Returns the md5 hash of the sorted content of the composer file.
-     *
-     * @see https://github.com/composer/composer/blob/master/src/Composer/Package/Locker.php (getContentHash() method)
-     *
-     * @param string $composerJsonFileContents The contents of the composer.json file.
-     *
-     * @return string The hash of the composer file content.
+     * {@inheritdoc}
      */
-    private function getComposerContentHash($composerJsonFileContents)
+    protected function getDownloadedApplicationType()
     {
-        $composerConfig = json_decode($composerJsonFileContents, true);
-
-        $relevantKeys = array(
-            'name',
-            'version',
-            'require',
-            'require-dev',
-            'conflict',
-            'replace',
-            'provide',
-            'minimum-stability',
-            'prefer-stable',
-            'repositories',
-            'extra',
-        );
-
-        $relevantComposerConfig = array();
-
-        foreach (array_intersect($relevantKeys, array_keys($composerConfig)) as $key) {
-            $relevantComposerConfig[$key] = $composerConfig[$key];
-        }
-
-        if (isset($composerConfig['config']['platform'])) {
-            $relevantComposerConfig['config']['platform'] = $composerConfig['config']['platform'];
-        }
-
-        ksort($relevantComposerConfig);
-
-        return md5(json_encode($relevantComposerConfig));
+        return 'Symfony';
     }
 
     /**
-     * Transforms a project name into a valid Composer package name.
-     *
-     * @param string $name The project name to transform
-     *
-     * @return string The valid Composer package name
+     * {@inheritdoc}
      */
-    private function fixPackageName($name)
+    protected function getRemoteFileUrl()
     {
-        $name = str_replace(
-            ['à', 'á', 'â', 'ä', 'æ', 'ã', 'å', 'ā', 'é', 'è', 'ê', 'ë', 'ę', 'ė', 'ē', 'ī', 'į', 'í', 'ì', 'ï', 'î', 'ō', 'ø', 'œ', 'õ', 'ó', 'ò', 'ö', 'ô', 'ū', 'ú', 'ù', 'ü', 'û', 'ç', 'ć', 'č', 'ł', 'ñ', 'ń', 'ß', 'ś', 'š', 'ŵ', 'ŷ', 'ÿ', 'ź', 'ž', 'ż'],
-            ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'e', 'e', 'e', 'e', 'e', 'e', 'e', 'i', 'i', 'i', 'i', 'i', 'i', 'o', 'o', 'o', 'o', 'o', 'o', 'o', 'o', 'u', 'u', 'u', 'u', 'u', 'c', 'c', 'c', 'l', 'n', 'n', 's', 's', 's', 'w', 'y', 'y', 'z', 'z', 'z'],
-            $name
-        );
-        $name = preg_replace('#[^A-Za-z0-9_./-]+#', '', $name);
-
-        return strtolower($name);
+        return 'http://symfony.com/download?v=Symfony_Standard_Vendors_'.$this->version;
     }
 }

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Installer\Exception\AbortException;
+use Symfony\Installer\Manager\ComposerManager;
 
 /**
  * This command creates new Symfony projects for the given Symfony version.
@@ -48,6 +49,8 @@ class NewCommand extends DownloadCommand
         $this->version = trim($input->getArgument('version'));
         $this->projectDir = $this->fs->isAbsolutePath($directory) ? $directory : getcwd().DIRECTORY_SEPARATOR.$directory;
         $this->projectName = basename($directory);
+
+        $this->composerManager = new ComposerManager($this->projectDir);
     }
 
     /**
@@ -66,7 +69,7 @@ class NewCommand extends DownloadCommand
                 ->cleanUp()
                 ->dumpReadmeFile()
                 ->updateParameters()
-                ->updateComposerJson()
+                ->updateComposerConfig()
                 ->createGitIgnore()
                 ->checkSymfonyRequirements()
                 ->displayInstallationResult()
@@ -322,69 +325,17 @@ class NewCommand extends DownloadCommand
      *
      * @return $this
      */
-    protected function updateComposerJson()
+    protected function updateComposerConfig()
     {
-        parent::updateComposerJson();
-
-        $composerConfig = $this->getProjectComposerConfig();
-
-        $composerConfig['name'] = $this->generateComposerProjectName();
-        $composerConfig['license'] = 'proprietary';
-
-        if (isset($composerConfig['description'])) {
-            unset($composerConfig['description']);
-        }
-
-        if (isset($composerConfig['extra']['branch-alias'])) {
-            unset($composerConfig['extra']['branch-alias']);
-        }
-
-        $this->saveProjectComposerConfig($composerConfig);
+        parent::updateComposerConfig();
+        $this->composerManager->updateProjectConfig([
+            'name' => $this->composerManager->createPackageName($this->projectName),
+            'license' => 'proprietary',
+            'description' => null,
+            'extra' => ['branch-alias' => null],
+        ]);
 
         return $this;
-    }
-
-    /**
-     * Generates a good Composer project name based on the application name
-     * and on the user name.
-     *
-     * @return string The generated Composer project name
-     */
-    protected function generateComposerProjectName()
-    {
-        $name = $this->projectName;
-
-        if (!empty($_SERVER['USERNAME'])) {
-            $name = $_SERVER['USERNAME'].'/'.$name;
-        } elseif (true === extension_loaded('posix') && $user = posix_getpwuid(posix_getuid())) {
-            $name = $user['name'].'/'.$name;
-        } elseif (get_current_user()) {
-            $name = get_current_user().'/'.$name;
-        } else {
-            // package names must be in the format foo/bar
-            $name = $name.'/'.$name;
-        }
-
-        return $this->fixComposerPackageName($name);
-    }
-
-    /**
-     * Transforms uppercase strings into dash-separated strings
-     * (e.g. FooBar -> foo-bar) to comply with Composer rules for package names.
-     *
-     * @param string $name The project name to transform
-     *
-     * @return string The fixed Composer project name
-     */
-    private function fixComposerPackageName($name)
-    {
-        return strtolower(
-            preg_replace(
-                array('/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'),
-                array('\\1-\\2', '\\1-\\2'),
-                strtr($name, '-', '.')
-            )
-        );
     }
 
     /**

--- a/tests/Symfony/Installer/Tests/Manager/ComposerManagerTest.php
+++ b/tests/Symfony/Installer/Tests/Manager/ComposerManagerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Symfony\Installer\Tests\Composer;
+
+use Symfony\Installer\Manager\ComposerManager;
+
+class ComposerManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getProjectNames
+     */
+    public function testFixPackageName($originalName, $expectedName)
+    {
+        $composerManager = new ComposerManager(sys_get_temp_dir());
+        $method = new \ReflectionMethod($composerManager, 'fixPackageName');
+        $method->setAccessible(true);
+
+        $fixedName = $method->invoke($composerManager, $originalName);
+        $this->assertSame($expectedName, $fixedName);
+    }
+
+    public function getProjectNames()
+    {
+        return [
+            ['foo/bar', 'foo/bar'],
+            ['áèî/øū', 'aei/ou'],
+            ['çñß/łŵž', 'cns/lwz'],
+            ['foo#bar\foo?bar=foo!bar{foo]bar', 'foobarfoobarfoobarfoobar'],
+            ['FOO/bar', 'foo/bar'],
+        ];
+    }
+}


### PR DESCRIPTION
* This is just a code refactor, no new features were introduced.
* This is the first step into improving the code quality and making it easier to test.

---

I have a question: I don't know which is the best way to uncomment [these lines](https://github.com/symfony/symfony-installer/compare/master...javiereguiluz:refactor_composer?expand=1#diff-32356c397bce66f4bdab4408a6c6ef72R92). Should we pass the `output` object to the Composer manager? Thanks.