### PR TITLE
Use 'server:start' instead of 'server:run' when possible

### DIFF
--- a/src/Symfony/Installer/DemoCommand.php
+++ b/src/Symfony/Installer/DemoCommand.php
@@ -145,7 +145,7 @@ class DemoCommand extends DownloadCommand
             ));
         }
 
-        $serverRunCommand = extension_loaded('pcntl') ? 'server:start' : 'server:run';
+        $serverRunCommand = version_compare($this->version, '2.6.0', '>=') && extension_loaded('pcntl') ? 'server:start' : 'server:run';
 
         $this->output->writeln(sprintf(
             "    1. Change your current directory to <comment>%s</comment>\n\n".

--- a/src/Symfony/Installer/DemoCommand.php
+++ b/src/Symfony/Installer/DemoCommand.php
@@ -145,7 +145,7 @@ class DemoCommand extends DownloadCommand
             ));
         }
 
-        $serverRunCommand = version_compare($this->version, '2.6.0', '>=') && extension_loaded('pcntl') ? 'server:start' : 'server:run';
+        $serverRunCommand = extension_loaded('pcntl') ? 'server:start' : 'server:run';
 
         $this->output->writeln(sprintf(
             "    1. Change your current directory to <comment>%s</comment>\n\n".

--- a/src/Symfony/Installer/DemoCommand.php
+++ b/src/Symfony/Installer/DemoCommand.php
@@ -145,11 +145,13 @@ class DemoCommand extends DownloadCommand
             ));
         }
 
+        $serverRunCommand = extension_loaded('pcntl') ? 'server:start' : 'server:run';
+
         $this->output->writeln(sprintf(
             "    1. Change your current directory to <comment>%s</comment>\n\n".
-            "    2. Execute the <comment>php bin/console server:run</comment> command to run the demo application.\n\n".
+            "    2. Execute the <comment>php bin/console %s</comment> command to run the demo application.\n\n".
             "    3. Browse to the <comment>http://localhost:8000</comment> URL to see the demo application in action.\n\n",
-            $this->projectDir
+            $this->projectDir, $serverRunCommand
         ));
 
         return $this;

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -256,7 +256,7 @@ class NewCommand extends DownloadCommand
         }
 
         $consoleDir = ($this->isSymfony3() ? 'bin' : 'app');
-        $serverRunCommand = extension_loaded('pcntl') ? 'server:start' : 'server:run';
+        $serverRunCommand = version_compare($this->version, '2.6.0', '>=') && extension_loaded('pcntl') ? 'server:start' : 'server:run';
 
         $this->output->writeln(sprintf(
             "    * Configure your application in <comment>app/config/parameters.yml</comment> file.\n\n".

--- a/src/Symfony/Installer/NewCommand.php
+++ b/src/Symfony/Installer/NewCommand.php
@@ -256,14 +256,15 @@ class NewCommand extends DownloadCommand
         }
 
         $consoleDir = ($this->isSymfony3() ? 'bin' : 'app');
+        $serverRunCommand = extension_loaded('pcntl') ? 'server:start' : 'server:run';
 
         $this->output->writeln(sprintf(
             "    * Configure your application in <comment>app/config/parameters.yml</comment> file.\n\n".
             "    * Run your application:\n".
-            "        1. Execute the <comment>php %s/console server:run</comment> command.\n".
+            "        1. Execute the <comment>php %s/console %s</comment> command.\n".
             "        2. Browse to the <comment>http://localhost:8000</comment> URL.\n\n".
             "    * Read the documentation at <comment>http://symfony.com/doc</comment>\n",
-            $consoleDir
+            $consoleDir, $serverRunCommand
         ));
 
         return $this;


### PR DESCRIPTION
`server:start` is a better option ... but it's not always possible to run it.