### PR TITLE
Display a warning message when installing the Demo application

### DIFF
--- a/src/Symfony/Installer/DemoCommand.php
+++ b/src/Symfony/Installer/DemoCommand.php
@@ -157,6 +157,13 @@ class DemoCommand extends DownloadCommand
             $this->projectDir, $serverRunCommand
         ));
 
+        $this->output->writeln(
+            "<bg=yellow> WARNING </>\n\n".
+            "   This installer downloads the old Symfony Demo version based on Symfony 3.\n".
+            "   If you prefer to install the new version based on Symfony 4 and Symfony Flex,\n".
+            "   execute the following command:\n\n".
+            "     composer create-project symfony/symfony-demo\n");
+
         return $this;
     }
 


### PR DESCRIPTION
This fixes #308 and it looks like this:

![warning-demo-project](https://user-images.githubusercontent.com/73419/38092665-3595370e-3369-11e8-91a8-0a9e24955770.png)
