### PR TITLE
fix edge case with openssl_random_pseudo_bytes

### DIFF
--- a/src/Symfony/Installer/DownloadCommand.php
+++ b/src/Symfony/Installer/DownloadCommand.php
@@ -468,11 +468,16 @@ abstract class DownloadCommand extends Command
      */
     protected function generateRandomSecret()
     {
+        $random = '';
         if (function_exists('openssl_random_pseudo_bytes')) {
-            return hash('sha1', openssl_random_pseudo_bytes(23));
+            $random = openssl_random_pseudo_bytes(23);
+        }
+        
+        if ($random === '') {
+            $random = uniqid(mt_rand(), true);
         }
 
-        return hash('sha1', uniqid(mt_rand(), true));
+        return hash('sha1', $random);
     }
 
     /**

--- a/src/Symfony/Installer/DownloadCommand.php
+++ b/src/Symfony/Installer/DownloadCommand.php
@@ -473,7 +473,7 @@ abstract class DownloadCommand extends Command
             $random = openssl_random_pseudo_bytes(23);
         }
         
-        if ($random === '') {
+        if ($random === false) {
             $random = uniqid(mt_rand(), true);
         }
 


### PR DESCRIPTION
In some cases openssl_random_pseudo_bytes can return an empty string. This PR try to account for that and fallback to the usage of uniqid.